### PR TITLE
chore: update sync start height to 875000

### DIFF
--- a/1-Identities-and-Names/identity-register.js
+++ b/1-Identities-and-Names/identity-register.js
@@ -8,7 +8,7 @@ const clientOpts = {
   wallet: {
     mnemonic: process.env.MNEMONIC, // A Dash wallet mnemonic with testnet funds
     unsafeOptions: {
-      skipSynchronizationBeforeHeight: 675000, // only sync from early-2022
+      skipSynchronizationBeforeHeight: 875000, // only sync from mid-2023
     },
   },
 };

--- a/1-Identities-and-Names/identity-retrieve-account-ids.js
+++ b/1-Identities-and-Names/identity-retrieve-account-ids.js
@@ -8,7 +8,7 @@ const client = new Dash.Client({
   wallet: {
     mnemonic: process.env.MNEMONIC, // A Dash wallet mnemonic with testnet funds
     unsafeOptions: {
-      skipSynchronizationBeforeHeight: 675000, // only sync from early-2022
+      skipSynchronizationBeforeHeight: 875000, // only sync from mid-2023
     },
   },
 });

--- a/1-Identities-and-Names/identity-topup.js
+++ b/1-Identities-and-Names/identity-topup.js
@@ -8,7 +8,7 @@ const clientOpts = {
   wallet: {
     mnemonic: process.env.MNEMONIC, // A Dash wallet mnemonic with testnet funds
     unsafeOptions: {
-      skipSynchronizationBeforeHeight: 675000, // only sync from early-2022
+      skipSynchronizationBeforeHeight: 875000, // only sync from mid-2023
     },
   },
 };

--- a/1-Identities-and-Names/identity-transfer-credits.js
+++ b/1-Identities-and-Names/identity-transfer-credits.js
@@ -8,7 +8,7 @@ const clientOpts = {
   wallet: {
     mnemonic: process.env.MNEMONIC, // A Dash wallet mnemonic with testnet funds
     unsafeOptions: {
-      skipSynchronizationBeforeHeight: process.env.SYNC_START_HEIGHT, // only sync from early-2022
+      skipSynchronizationBeforeHeight: process.env.SYNC_START_HEIGHT, // only sync from mid-2023
     },
   },
 };

--- a/1-Identities-and-Names/identity-update-add-key.js
+++ b/1-Identities-and-Names/identity-update-add-key.js
@@ -11,7 +11,7 @@ const clientOpts = {
   wallet: {
     mnemonic: process.env.MNEMONIC, // A Dash wallet mnemonic with testnet funds
     unsafeOptions: {
-      skipSynchronizationBeforeHeight: 675000, // only sync from early-2022
+      skipSynchronizationBeforeHeight: 875000, // only sync from mid-2023
     },
   },
 };

--- a/1-Identities-and-Names/identity-update-disable-key.js
+++ b/1-Identities-and-Names/identity-update-disable-key.js
@@ -8,7 +8,7 @@ const clientOpts = {
   wallet: {
     mnemonic: process.env.MNEMONIC, // A Dash wallet mnemonic with testnet funds
     unsafeOptions: {
-      skipSynchronizationBeforeHeight: 675000, // only sync from early-2022
+      skipSynchronizationBeforeHeight: 875000, // only sync from mid-2023
     },
   },
 };

--- a/1-Identities-and-Names/name-register-alias.js
+++ b/1-Identities-and-Names/name-register-alias.js
@@ -10,7 +10,7 @@ const clientOpts = {
   wallet: {
     mnemonic: process.env.MNEMONIC, // A Dash wallet mnemonic with testnet funds
     unsafeOptions: {
-      skipSynchronizationBeforeHeight: 675000, // only sync from early-2022
+      skipSynchronizationBeforeHeight: 875000, // only sync from mid-2023
     },
   },
 };

--- a/1-Identities-and-Names/name-register.js
+++ b/1-Identities-and-Names/name-register.js
@@ -10,7 +10,7 @@ const clientOpts = {
   wallet: {
     mnemonic: process.env.MNEMONIC, // A Dash wallet mnemonic with testnet funds
     unsafeOptions: {
-      skipSynchronizationBeforeHeight: 675000, // only sync from early-2022
+      skipSynchronizationBeforeHeight: 875000, // only sync from mid-2023
     },
   },
 };

--- a/2-Contracts-and-Documents/contract-register-history.js
+++ b/2-Contracts-and-Documents/contract-register-history.js
@@ -8,7 +8,7 @@ const clientOpts = {
   wallet: {
     mnemonic: process.env.MNEMONIC, // A Dash wallet mnemonic with testnet funds
     unsafeOptions: {
-      skipSynchronizationBeforeHeight: 675000, // only sync from early-2022
+      skipSynchronizationBeforeHeight: 875000, // only sync from mid-2023
     },
   },
 };

--- a/2-Contracts-and-Documents/contract-register-minimal.js
+++ b/2-Contracts-and-Documents/contract-register-minimal.js
@@ -8,7 +8,7 @@ const clientOpts = {
   wallet: {
     mnemonic: process.env.MNEMONIC, // A Dash wallet mnemonic with testnet funds
     unsafeOptions: {
-      skipSynchronizationBeforeHeight: 675000, // only sync from early-2022
+      skipSynchronizationBeforeHeight: 875000, // only sync from mid-2023
     },
   },
 };

--- a/2-Contracts-and-Documents/contract-update-history.js
+++ b/2-Contracts-and-Documents/contract-update-history.js
@@ -8,7 +8,7 @@ const clientOpts = {
   wallet: {
     mnemonic: process.env.MNEMONIC, // A Dash wallet mnemonic with testnet funds
     unsafeOptions: {
-      skipSynchronizationBeforeHeight: 675000, // only sync from early-2022
+      skipSynchronizationBeforeHeight: 875000, // only sync from mid-2023
     },
   },
 };

--- a/2-Contracts-and-Documents/contract-update-minimal.js
+++ b/2-Contracts-and-Documents/contract-update-minimal.js
@@ -8,7 +8,7 @@ const clientOpts = {
   wallet: {
     mnemonic: process.env.MNEMONIC, // A Dash wallet mnemonic with testnet funds
     unsafeOptions: {
-      skipSynchronizationBeforeHeight: 675000, // only sync from early-2022
+      skipSynchronizationBeforeHeight: 875000, // only sync from mid-2023
     },
   },
 };

--- a/2-Contracts-and-Documents/document-delete.js
+++ b/2-Contracts-and-Documents/document-delete.js
@@ -8,7 +8,7 @@ const clientOpts = {
   wallet: {
     mnemonic: process.env.MNEMONIC, // A Dash wallet mnemonic with testnet funds
     unsafeOptions: {
-      skipSynchronizationBeforeHeight: 675000, // only sync from early-2022
+      skipSynchronizationBeforeHeight: 875000, // only sync from mid-2023
     },
   },
   apps: {

--- a/2-Contracts-and-Documents/document-submit.js
+++ b/2-Contracts-and-Documents/document-submit.js
@@ -8,7 +8,7 @@ const clientOpts = {
   wallet: {
     mnemonic: process.env.MNEMONIC, // A Dash wallet mnemonic with testnet funds
     unsafeOptions: {
-      skipSynchronizationBeforeHeight: 675000, // only sync from early-2022
+      skipSynchronizationBeforeHeight: 875000, // only sync from mid-2023
     },
   },
   apps: {

--- a/2-Contracts-and-Documents/document-update.js
+++ b/2-Contracts-and-Documents/document-update.js
@@ -8,7 +8,7 @@ const clientOpts = {
   wallet: {
     mnemonic: process.env.MNEMONIC, // A Dash wallet mnemonic with testnet funds
     unsafeOptions: {
-      skipSynchronizationBeforeHeight: 650000, // only sync from early-2022
+      skipSynchronizationBeforeHeight: 875000, // only sync from mid-2023
     },
   },
   apps: {

--- a/send-funds.js
+++ b/send-funds.js
@@ -8,7 +8,7 @@ const clientOpts = {
   wallet: {
     mnemonic: process.env.MNEMONIC, // A Dash wallet mnemonic with testnet funds
     unsafeOptions: {
-      skipSynchronizationBeforeHeight: 675000, // only sync from early-2022
+      skipSynchronizationBeforeHeight: 875000, // only sync from mid-2023
     },
   },
 };


### PR DESCRIPTION
Updates the sync start height to a more recent block for quicker wallet operations.