### PR TITLE
chore: update sdk to v1-dev

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "platform-readme-tutorials",
-  "version": "0.25.21",
+  "version": "1.0.0-dev",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "platform-readme-tutorials",
-      "version": "0.25.21",
+      "version": "1.0.0-dev",
       "license": "MIT",
       "dependencies": {
-        "dash": "^3.25.21"
+        "dash": "^4.0.0-dev.5"
       },
       "devDependencies": {
         "dotenv": "^16.0.0",
@@ -221,15 +221,15 @@
       }
     },
     "node_modules/@dashevo/dapi-client": {
-      "version": "0.25.21",
-      "resolved": "https://registry.npmjs.org/@dashevo/dapi-client/-/dapi-client-0.25.21.tgz",
-      "integrity": "sha512-dAzP/IK/1XSqUlZn+vkqmhcki1KQcOzvbvZylA+oTlXkbQTR9OJk+wLojPoyWmFt0qIhqb85o+15g1DlzJ1TrA==",
+      "version": "1.0.0-dev.5",
+      "resolved": "https://registry.npmjs.org/@dashevo/dapi-client/-/dapi-client-1.0.0-dev.5.tgz",
+      "integrity": "sha512-npUu40ycbc5CChOz09R+tWRyln5QVYFniporO76qYjA8Ad+87kCWXxl5/rFIZy5enwxnj+NgBMrZMgy3gmYtTA==",
       "dependencies": {
-        "@dashevo/dapi-grpc": "0.25.21",
-        "@dashevo/dash-spv": "0.25.21",
-        "@dashevo/dashcore-lib": "~0.21.0",
-        "@dashevo/grpc-common": "0.25.21",
-        "@dashevo/wasm-dpp": "0.25.21",
+        "@dashevo/dapi-grpc": "1.0.0-dev.5",
+        "@dashevo/dash-spv": "1.0.0-dev.5",
+        "@dashevo/dashcore-lib": "~0.21.1",
+        "@dashevo/grpc-common": "1.0.0-dev.5",
+        "@dashevo/wasm-dpp": "1.0.0-dev.5",
         "bs58": "^4.0.1",
         "cbor": "^8.0.0",
         "google-protobuf": "^3.12.2",
@@ -241,11 +241,11 @@
       }
     },
     "node_modules/@dashevo/dapi-grpc": {
-      "version": "0.25.21",
-      "resolved": "https://registry.npmjs.org/@dashevo/dapi-grpc/-/dapi-grpc-0.25.21.tgz",
-      "integrity": "sha512-Fxs2Q0SZRaL5puuC5Oww7SR8+d0FxtWThWvD0rPuYYuVUuZ0RwmF664DAVcO/L1m5dYEIOPUeTbt1Y0uYy1YOQ==",
+      "version": "1.0.0-dev.5",
+      "resolved": "https://registry.npmjs.org/@dashevo/dapi-grpc/-/dapi-grpc-1.0.0-dev.5.tgz",
+      "integrity": "sha512-CGN1ssF0cywCuX6U9ZS7B9oUyoyeZ9HfzsRCE1g6mEO1CvSTwwyNVXqDjRJ0Xov7eJ//lSkcL4ydtKqGKi8oAQ==",
       "dependencies": {
-        "@dashevo/grpc-common": "0.25.21",
+        "@dashevo/grpc-common": "1.0.0-dev.5",
         "@dashevo/protobufjs": "6.10.5",
         "@grpc/grpc-js": "1.4.4",
         "@improbable-eng/grpc-web": "^0.15.0",
@@ -259,13 +259,13 @@
       "integrity": "sha512-rt0PzGzqplqERWVIMLlBxm4mJqjFTYNUFRhIccbfaF/MDyd0/585krGOWIhe0Sis9XQNA/FJlxxRjtPXIcyyCg=="
     },
     "node_modules/@dashevo/dash-spv": {
-      "version": "0.25.21",
-      "resolved": "https://registry.npmjs.org/@dashevo/dash-spv/-/dash-spv-0.25.21.tgz",
-      "integrity": "sha512-g5vTlz6aH4mmJgWenSeuIL9hToBqoR6WrqytAlf46lCbMLUxf7Ox5vAEfk1VwQir7/fnEjQovmwNRb1ztWqODQ==",
+      "version": "1.0.0-dev.5",
+      "resolved": "https://registry.npmjs.org/@dashevo/dash-spv/-/dash-spv-1.0.0-dev.5.tgz",
+      "integrity": "sha512-7Ll+tqDaOMPuNIllP5cAki+31szWTrpz4ZoWw6l3EwWDzmDQt0poL2PFp50d/RwuRZPuatXEGUBfIwB0MzT1MQ==",
       "dependencies": {
         "@dashevo/dark-gravity-wave": "^1.1.1",
         "@dashevo/dash-util": "^2.0.3",
-        "@dashevo/dashcore-lib": "~0.21.0",
+        "@dashevo/dashcore-lib": "~0.21.1",
         "levelup": "^4.4.0",
         "memdown": "^5.1.0",
         "wasm-x11-hash": "~0.0.2"
@@ -281,9 +281,9 @@
       }
     },
     "node_modules/@dashevo/dashcore-lib": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/@dashevo/dashcore-lib/-/dashcore-lib-0.21.0.tgz",
-      "integrity": "sha512-pWrR1G/rgP+IfN59L005KeHEo+OKblkVNP8cC8GUrMkKKS7QrCNHi/F/DBb7zMcbo5NbIWJ1QYdK11Ya6nE3tQ==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@dashevo/dashcore-lib/-/dashcore-lib-0.21.1.tgz",
+      "integrity": "sha512-ZRzzvIkB5NtS04QmBDOPBqyMQTV+yzrUc/T+TbsKcF5FdapQCAzN4HnTsIXKLenPk2TpW/j68yFwoA1tj3eRXA==",
       "dependencies": {
         "@dashevo/bls": "~1.2.9",
         "@dashevo/x11-hash-js": "^1.0.2",
@@ -300,19 +300,19 @@
       }
     },
     "node_modules/@dashevo/dashpay-contract": {
-      "version": "0.25.21",
-      "resolved": "https://registry.npmjs.org/@dashevo/dashpay-contract/-/dashpay-contract-0.25.21.tgz",
-      "integrity": "sha512-jsLgkGJoRu1EmWa+w0auEVYmW/acpLdr+um4KFdKZ/N74xmrL5w1nXU6FzHg8mgI8dfrmrcInKEoCDA16S1nJA=="
+      "version": "1.0.0-dev.5",
+      "resolved": "https://registry.npmjs.org/@dashevo/dashpay-contract/-/dashpay-contract-1.0.0-dev.5.tgz",
+      "integrity": "sha512-t/vw4fTxEV5To9r+XoRYVzn8VHkh9eeQTae2Y9wlDZ9RGrDUl6PFkov+idcwnE9RzXjhpYkICca8Wo1VtYKO8Q=="
     },
     "node_modules/@dashevo/dpns-contract": {
-      "version": "0.25.21",
-      "resolved": "https://registry.npmjs.org/@dashevo/dpns-contract/-/dpns-contract-0.25.21.tgz",
-      "integrity": "sha512-iyRX7Lmzz60Tt3spDgIMmsA1yIVtHSrkEvBURPLzSW2umAkjNhvra0rGDmDSVpF3bVNhJDtoPrepXmT1wh8sEA=="
+      "version": "1.0.0-dev.5",
+      "resolved": "https://registry.npmjs.org/@dashevo/dpns-contract/-/dpns-contract-1.0.0-dev.5.tgz",
+      "integrity": "sha512-Lp4PuDbwh/4Z6ufAQUz4oZuCyxBeFGQLDT1kyUB5K8tNMcaceY+gZQUPR5g5AGngY9KV8Z86hPUgpZDRXhdW7g=="
     },
     "node_modules/@dashevo/grpc-common": {
-      "version": "0.25.21",
-      "resolved": "https://registry.npmjs.org/@dashevo/grpc-common/-/grpc-common-0.25.21.tgz",
-      "integrity": "sha512-PKmzMK34bXyJshWd/IoNZv8fT+MxQciTlkVO1UPrGSGIODBIZlt8HA65He6qehujdp800hpUZX3l6w3Y+HAplw==",
+      "version": "1.0.0-dev.5",
+      "resolved": "https://registry.npmjs.org/@dashevo/grpc-common/-/grpc-common-1.0.0-dev.5.tgz",
+      "integrity": "sha512-j2lustteb7iIKqW3FiCWyyaL+5PRZSHczp8lWg+hPQkqQpsSHTpmtB2DsAaL9jHa9WW7TVzeGATXsRT8YcX+TA==",
       "dependencies": {
         "@dashevo/protobufjs": "6.10.5",
         "@grpc/grpc-js": "1.4.4",
@@ -324,9 +324,9 @@
       }
     },
     "node_modules/@dashevo/masternode-reward-shares-contract": {
-      "version": "0.25.21",
-      "resolved": "https://registry.npmjs.org/@dashevo/masternode-reward-shares-contract/-/masternode-reward-shares-contract-0.25.21.tgz",
-      "integrity": "sha512-KgOMHjETtp6KaM0Dp/hi3G9RU7Nd0dxHOWDNJt/2lIO6d3eXHgsMqrTAjH5THHPWf11FOgD21f4AkaMstaTYCg=="
+      "version": "1.0.0-dev.5",
+      "resolved": "https://registry.npmjs.org/@dashevo/masternode-reward-shares-contract/-/masternode-reward-shares-contract-1.0.0-dev.5.tgz",
+      "integrity": "sha512-x0IJhpRW68XerAdz9d8yYGhar3UlRpOEJiZtr/1s2ep1HUPDJpA1nbQznrb4daWqEmRHTEROyCXsBE+i1hgoJQ=="
     },
     "node_modules/@dashevo/protobufjs": {
       "version": "6.10.5",
@@ -364,14 +364,14 @@
       "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
     },
     "node_modules/@dashevo/wallet-lib": {
-      "version": "7.25.21",
-      "resolved": "https://registry.npmjs.org/@dashevo/wallet-lib/-/wallet-lib-7.25.21.tgz",
-      "integrity": "sha512-7H5E4plFwKSC8GqH7xiUg6UstyP8+ocIEhTKTjU4HURsu2Q7uUxL5sWL8Pxw3Unz1ZUQRMbiPKhxJBID9yQvxw==",
+      "version": "8.0.0-dev.5",
+      "resolved": "https://registry.npmjs.org/@dashevo/wallet-lib/-/wallet-lib-8.0.0-dev.5.tgz",
+      "integrity": "sha512-GyWRrB8dTM0FTnr2YsFkp8OUTfVTKWdCZxJLF083pOufubA/PvAdRwUTzR7wzi1vO6CEWGAwDitPqEKDD8VIVw==",
       "dependencies": {
-        "@dashevo/dapi-client": "0.25.21",
-        "@dashevo/dashcore-lib": "~0.21.0",
-        "@dashevo/grpc-common": "0.25.21",
-        "@dashevo/wasm-dpp": "0.25.21",
+        "@dashevo/dapi-client": "1.0.0-dev.5",
+        "@dashevo/dashcore-lib": "~0.21.1",
+        "@dashevo/grpc-common": "1.0.0-dev.5",
+        "@dashevo/wasm-dpp": "1.0.0-dev.5",
         "@yarnpkg/pnpify": "^4.0.0-rc.42",
         "cbor": "^8.0.0",
         "crypto-js": "^4.2.0",
@@ -382,15 +382,20 @@
       }
     },
     "node_modules/@dashevo/wasm-dpp": {
-      "version": "0.25.21",
-      "resolved": "https://registry.npmjs.org/@dashevo/wasm-dpp/-/wasm-dpp-0.25.21.tgz",
-      "integrity": "sha512-BWiMLKfWP5vUVvo3LAaX5cckZ4e7VCt/DC3iBnsLMs0vQFFzn+IMS38MgSWOCQiQywWNeCdiAzKyyEQ9p7kv9A==",
+      "version": "1.0.0-dev.5",
+      "resolved": "https://registry.npmjs.org/@dashevo/wasm-dpp/-/wasm-dpp-1.0.0-dev.5.tgz",
+      "integrity": "sha512-w7KmU69t4hTjUymttvTaIRCBBGjEYuaXY488C1uEFuCLjdIlElDoJbjBR1CO2ltQqh9Fa+oBC1+z3WgX9Fa93w==",
       "dependencies": {
         "@dashevo/bls": "~1.2.9",
         "bs58": "^4.0.1",
         "lodash": "^4.17.21",
         "varint": "^6.0.0"
       }
+    },
+    "node_modules/@dashevo/withdrawals-contract": {
+      "version": "1.0.0-dev.5",
+      "resolved": "https://registry.npmjs.org/@dashevo/withdrawals-contract/-/withdrawals-contract-1.0.0-dev.5.tgz",
+      "integrity": "sha512-2Mcu2fl3RFGYpZ8EvMz8Ia6JLmdLF3PlgFBaowFUKO6+aJpRCXMYoScBfQ/hFD4t6iAI4Sih7o1MB8pIz/ucSA=="
     },
     "node_modules/@dashevo/x11-hash-js": {
       "version": "1.0.2",
@@ -790,9 +795,9 @@
       }
     },
     "node_modules/@types/semver": {
-      "version": "7.5.6",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.6.tgz",
-      "integrity": "sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A=="
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.7.tgz",
+      "integrity": "sha512-/wdoPq1QqkSj9/QOeKkFquEuPzQbHTWAMPH/PaUMB+JuR31lXhlWXRZ52IpfDYVlDOUBvX09uBrPwxGT1hjNBg=="
     },
     "node_modules/@types/treeify": {
       "version": "1.0.3",
@@ -805,15 +810,15 @@
       "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw=="
     },
     "node_modules/@yarnpkg/core": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@yarnpkg/core/-/core-4.0.2.tgz",
-      "integrity": "sha512-YSibU3htZ3ZyslCUCG0aI4xcnmPZwZnHSUYl8TgC/Ck3++9xr474Mzh3t4Zv8olh9BguMC7FmRSpKAThiaFafw==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/core/-/core-4.0.3.tgz",
+      "integrity": "sha512-O+WGCjB9aIBxdRMBxXdsIy08MW4RbxfCS2AfywWb8DPS9H0LICahUJgNAaE0fwCsW7/gNzQbLYlh9DQQwzONrA==",
       "dependencies": {
         "@arcanis/slice-ansi": "^1.1.1",
         "@types/semver": "^7.1.0",
         "@types/treeify": "^1.0.0",
-        "@yarnpkg/fslib": "^3.0.1",
-        "@yarnpkg/libzip": "^3.0.0",
+        "@yarnpkg/fslib": "^3.0.2",
+        "@yarnpkg/libzip": "^3.0.1",
         "@yarnpkg/parsers": "^3.0.0",
         "@yarnpkg/shell": "^4.0.0",
         "camelcase": "^5.3.1",
@@ -867,9 +872,9 @@
       }
     },
     "node_modules/@yarnpkg/fslib": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@yarnpkg/fslib/-/fslib-3.0.1.tgz",
-      "integrity": "sha512-TtodA4zcpKfMRI8iEBEGIRdwJ7uhj/ic2bDCBSdt6KU8WoLv9b91oqi6t37ttY7+c8B9z750W0PZHmQR3lpLNA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/fslib/-/fslib-3.0.2.tgz",
+      "integrity": "sha512-dqSpZCj9ZeqMZzITHvpi5qKS9MCLWZYCl6NHCSl3a+BqiyLApehWAy60zjv9F1fxKZ6RKDgHLhBWhx8RwPm6Dw==",
       "dependencies": {
         "tslib": "^2.4.0"
       },
@@ -878,29 +883,29 @@
       }
     },
     "node_modules/@yarnpkg/libzip": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@yarnpkg/libzip/-/libzip-3.0.0.tgz",
-      "integrity": "sha512-31NR8oHG/NLnSEqQOy48tnjNHgYPujOtammmvoItNAfsWAmaOqtDimwPRRPXGTNxC2SYYBYrk6pli5yti/Qmfw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/libzip/-/libzip-3.0.1.tgz",
+      "integrity": "sha512-fiqRLk2fyd2r34/Qc7HlP8fKIo1CK5CZpLNObJwnbFmZQN2hVanovFlG++3oH3qYJymEmjPl5EGsygcEJZl4Pg==",
       "dependencies": {
         "@types/emscripten": "^1.39.6",
-        "@yarnpkg/fslib": "^3.0.0",
+        "@yarnpkg/fslib": "^3.0.2",
         "tslib": "^2.4.0"
       },
       "engines": {
         "node": ">=18.12.0"
       },
       "peerDependencies": {
-        "@yarnpkg/fslib": "^3.0.0"
+        "@yarnpkg/fslib": "^3.0.2"
       }
     },
     "node_modules/@yarnpkg/nm": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@yarnpkg/nm/-/nm-4.0.1.tgz",
-      "integrity": "sha512-JWWTfqKX4Sci8kgN9ozGjk3HQLAXsaTIlHQfu4r1hsaS9Lw75Q1DLTfak94qN7PhM9UzKDCQD2U53aXhzgPXgQ==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/nm/-/nm-4.0.2.tgz",
+      "integrity": "sha512-TcoNjsT1r2fnC3/3FivIssXH3ZIdn0s75j6dDNUG8e9AbDRj6pDSxKp6p5KbLQ2LrTM9Zv73gRqe7lYeagBoTg==",
       "dependencies": {
-        "@yarnpkg/core": "^4.0.2",
-        "@yarnpkg/fslib": "^3.0.1",
-        "@yarnpkg/pnp": "^4.0.1"
+        "@yarnpkg/core": "^4.0.3",
+        "@yarnpkg/fslib": "^3.0.2",
+        "@yarnpkg/pnp": "^4.0.2"
       },
       "engines": {
         "node": ">=18.12.0"
@@ -919,21 +924,21 @@
       }
     },
     "node_modules/@yarnpkg/pnp": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@yarnpkg/pnp/-/pnp-4.0.1.tgz",
-      "integrity": "sha512-oxs80lP3qINsP2GjF/KvzIdhDUm45xwxWhYleLSDdRTGHdh5GiTghM6wXzfIbRJzb7R/jMCU4oGcLCSr+La4rw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/pnp/-/pnp-4.0.2.tgz",
+      "integrity": "sha512-fOZoZJP8AqHtAWlgZukbQu87lHtm2Hutz5EzahKx7756EfgkE3hcyp0PukYzO2GITPtgsNo5A0V4R1FgFJtAUA==",
       "dependencies": {
         "@types/node": "^18.17.15",
-        "@yarnpkg/fslib": "^3.0.1"
+        "@yarnpkg/fslib": "^3.0.2"
       },
       "engines": {
         "node": ">=18.12.0"
       }
     },
     "node_modules/@yarnpkg/pnp/node_modules/@types/node": {
-      "version": "18.19.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.6.tgz",
-      "integrity": "sha512-X36s5CXMrrJOs2lQCdDF68apW4Rfx9ixYMawlepwmE4Anezv/AV2LSpKD1Ub8DAc+urp5bk0BGZ6NtmBitfnsg==",
+      "version": "18.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.17.tgz",
+      "integrity": "sha512-SzyGKgwPzuWp2SHhlpXKzCX0pIOfcI4V2eF37nNBJOhwlegQ83omtVQ1XxZpDE06V/d6AQvfQdPfnw0tRC//Ng==",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -1340,9 +1345,9 @@
       }
     },
     "node_modules/clipanion": {
-      "version": "4.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/clipanion/-/clipanion-4.0.0-rc.2.tgz",
-      "integrity": "sha512-0IXugyri0bQs6/JLS9Uoh9xZ4kiDyFf6gAoikefPW/yHJZbS4We4jjx5HZPU/xfRjILSzZld9Q9P3JBJe6irUA==",
+      "version": "4.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/clipanion/-/clipanion-4.0.0-rc.3.tgz",
+      "integrity": "sha512-+rJOJMt2N6Oikgtfqmo/Duvme7uz3SIedL2b6ycgCztQMiTfr3aQh2DDyLHl+QUPClKMNpSg3gDJFvNQYIcq1g==",
       "dependencies": {
         "typanion": "^3.8.0"
       },
@@ -1477,20 +1482,21 @@
       "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
     },
     "node_modules/dash": {
-      "version": "3.25.21",
-      "resolved": "https://registry.npmjs.org/dash/-/dash-3.25.21.tgz",
-      "integrity": "sha512-CELZkCupQs+GbwkYohwmZkGYIpK4HhUPEFfF722syowHy7AaFILMSwngG7VptSQq0I4OZdUzfRN3lIC4BKMzdQ==",
+      "version": "4.0.0-dev.5",
+      "resolved": "https://registry.npmjs.org/dash/-/dash-4.0.0-dev.5.tgz",
+      "integrity": "sha512-EB2TiGZY2EDWm8Yc4nFFWp41zk/SAM3zznsL56Gj7GAvyYUbTj1NxLU0Ja1nN7ETSgFVoe4+PXV77x5fB1OQ/A==",
       "dependencies": {
         "@dashevo/bls": "~1.2.9",
-        "@dashevo/dapi-client": "0.25.21",
-        "@dashevo/dapi-grpc": "0.25.21",
-        "@dashevo/dashcore-lib": "~0.21.0",
-        "@dashevo/dashpay-contract": "0.25.21",
-        "@dashevo/dpns-contract": "0.25.21",
-        "@dashevo/grpc-common": "0.25.21",
-        "@dashevo/masternode-reward-shares-contract": "0.25.21",
-        "@dashevo/wallet-lib": "7.25.21",
-        "@dashevo/wasm-dpp": "0.25.21",
+        "@dashevo/dapi-client": "1.0.0-dev.5",
+        "@dashevo/dapi-grpc": "1.0.0-dev.5",
+        "@dashevo/dashcore-lib": "~0.21.1",
+        "@dashevo/dashpay-contract": "1.0.0-dev.5",
+        "@dashevo/dpns-contract": "1.0.0-dev.5",
+        "@dashevo/grpc-common": "1.0.0-dev.5",
+        "@dashevo/masternode-reward-shares-contract": "1.0.0-dev.5",
+        "@dashevo/wallet-lib": "8.0.0-dev.5",
+        "@dashevo/wasm-dpp": "1.0.0-dev.5",
+        "@dashevo/withdrawals-contract": "1.0.0-dev.5",
         "bs58": "^4.0.1",
         "node-inspect-extracted": "^1.0.8",
         "winston": "^3.2.1"
@@ -1601,9 +1607,9 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/diff": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
-      "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
+      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
       "engines": {
         "node": ">=0.3.1"
       }
@@ -1707,9 +1713,9 @@
       }
     },
     "node_modules/escalade": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
+      "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
       "engines": {
         "node": ">=6"
       }
@@ -2283,9 +2289,9 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/hasown": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
-      "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.1.tgz",
+      "integrity": "sha512-1/th4MHjnwncwXsIW6QMzlvYL9kG5e/CpVvLRZe4XPa8TOUNbCELqmvhDmnkNsAjwaG4+I8gJJL0JBvTTLO9qA==",
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -3269,9 +3275,9 @@
       }
     },
     "node_modules/protobufjs/node_modules/@types/node": {
-      "version": "20.10.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.8.tgz",
-      "integrity": "sha512-f8nQs3cLxbAFc00vEU59yf9UyGUftkPaLGfvbVOIDdx2i1b8epBqj2aNGyP19fiyXWvlmZ7qC1XLjAzw/OKIeA==",
+      "version": "20.11.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.19.tgz",
+      "integrity": "sha512-7xMnVEcZFu0DikYjWOlRq7NTPETrm7teqUT2WkQjrTIkEgUyyGdWsj/Zg8bEJt5TNklzbPD1X3fqfsHw3SpapQ==",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -3619,9 +3625,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -3699,9 +3705,9 @@
       }
     },
     "node_modules/spdx-exceptions": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
-      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+      "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w=="
     },
     "node_modules/spdx-expression-parse": {
       "version": "3.0.1",
@@ -3713,9 +3719,9 @@
       }
     },
     "node_modules/spdx-license-ids": {
-      "version": "3.0.16",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.16.tgz",
-      "integrity": "sha512-eWN+LnM3GR6gPu35WxNgbGl8rmY1AEmoMDvL/QD6zYmPWgywxWqJWNdLGT+ke8dKNWrcYgYjPpG5gbTfghP8rw=="
+      "version": "3.0.17",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.17.tgz",
+      "integrity": "sha512-sh8PWc/ftMqAAdFiBu6Fy6JUOYjqDJBJvIhpfDMyHrr0Rbp5liZqd4TjtQ/RgfLjKFZb+LMx5hpml5qOWy0qvg=="
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
@@ -4049,9 +4055,9 @@
       }
     },
     "node_modules/winston-transport": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.6.0.tgz",
-      "integrity": "sha512-wbBA9PbPAHxKiygo7ub7BYRiKxms0tpfU2ljtWzb3SjRjv5yl6Ozuy/TkXf00HTAt+Uylo3gSkNwzc4ME0wiIg==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.7.0.tgz",
+      "integrity": "sha512-ajBj65K5I7denzer2IYW6+2bNIVqLGDHqDw3Ow8Ohh+vdW+rv4MZ6eiDvHoKhfJFZ2auyN8byXieDDJ96ViONg==",
       "dependencies": {
         "logform": "^2.3.2",
         "readable-stream": "^3.6.0",
@@ -4306,15 +4312,15 @@
       }
     },
     "@dashevo/dapi-client": {
-      "version": "0.25.21",
-      "resolved": "https://registry.npmjs.org/@dashevo/dapi-client/-/dapi-client-0.25.21.tgz",
-      "integrity": "sha512-dAzP/IK/1XSqUlZn+vkqmhcki1KQcOzvbvZylA+oTlXkbQTR9OJk+wLojPoyWmFt0qIhqb85o+15g1DlzJ1TrA==",
+      "version": "1.0.0-dev.5",
+      "resolved": "https://registry.npmjs.org/@dashevo/dapi-client/-/dapi-client-1.0.0-dev.5.tgz",
+      "integrity": "sha512-npUu40ycbc5CChOz09R+tWRyln5QVYFniporO76qYjA8Ad+87kCWXxl5/rFIZy5enwxnj+NgBMrZMgy3gmYtTA==",
       "requires": {
-        "@dashevo/dapi-grpc": "0.25.21",
-        "@dashevo/dash-spv": "0.25.21",
-        "@dashevo/dashcore-lib": "~0.21.0",
-        "@dashevo/grpc-common": "0.25.21",
-        "@dashevo/wasm-dpp": "0.25.21",
+        "@dashevo/dapi-grpc": "1.0.0-dev.5",
+        "@dashevo/dash-spv": "1.0.0-dev.5",
+        "@dashevo/dashcore-lib": "~0.21.1",
+        "@dashevo/grpc-common": "1.0.0-dev.5",
+        "@dashevo/wasm-dpp": "1.0.0-dev.5",
         "bs58": "^4.0.1",
         "cbor": "^8.0.0",
         "google-protobuf": "^3.12.2",
@@ -4326,11 +4332,11 @@
       }
     },
     "@dashevo/dapi-grpc": {
-      "version": "0.25.21",
-      "resolved": "https://registry.npmjs.org/@dashevo/dapi-grpc/-/dapi-grpc-0.25.21.tgz",
-      "integrity": "sha512-Fxs2Q0SZRaL5puuC5Oww7SR8+d0FxtWThWvD0rPuYYuVUuZ0RwmF664DAVcO/L1m5dYEIOPUeTbt1Y0uYy1YOQ==",
+      "version": "1.0.0-dev.5",
+      "resolved": "https://registry.npmjs.org/@dashevo/dapi-grpc/-/dapi-grpc-1.0.0-dev.5.tgz",
+      "integrity": "sha512-CGN1ssF0cywCuX6U9ZS7B9oUyoyeZ9HfzsRCE1g6mEO1CvSTwwyNVXqDjRJ0Xov7eJ//lSkcL4ydtKqGKi8oAQ==",
       "requires": {
-        "@dashevo/grpc-common": "0.25.21",
+        "@dashevo/grpc-common": "1.0.0-dev.5",
         "@dashevo/protobufjs": "6.10.5",
         "@grpc/grpc-js": "1.4.4",
         "@improbable-eng/grpc-web": "^0.15.0",
@@ -4344,13 +4350,13 @@
       "integrity": "sha512-rt0PzGzqplqERWVIMLlBxm4mJqjFTYNUFRhIccbfaF/MDyd0/585krGOWIhe0Sis9XQNA/FJlxxRjtPXIcyyCg=="
     },
     "@dashevo/dash-spv": {
-      "version": "0.25.21",
-      "resolved": "https://registry.npmjs.org/@dashevo/dash-spv/-/dash-spv-0.25.21.tgz",
-      "integrity": "sha512-g5vTlz6aH4mmJgWenSeuIL9hToBqoR6WrqytAlf46lCbMLUxf7Ox5vAEfk1VwQir7/fnEjQovmwNRb1ztWqODQ==",
+      "version": "1.0.0-dev.5",
+      "resolved": "https://registry.npmjs.org/@dashevo/dash-spv/-/dash-spv-1.0.0-dev.5.tgz",
+      "integrity": "sha512-7Ll+tqDaOMPuNIllP5cAki+31szWTrpz4ZoWw6l3EwWDzmDQt0poL2PFp50d/RwuRZPuatXEGUBfIwB0MzT1MQ==",
       "requires": {
         "@dashevo/dark-gravity-wave": "^1.1.1",
         "@dashevo/dash-util": "^2.0.3",
-        "@dashevo/dashcore-lib": "~0.21.0",
+        "@dashevo/dashcore-lib": "~0.21.1",
         "levelup": "^4.4.0",
         "memdown": "^5.1.0",
         "wasm-x11-hash": "~0.0.2"
@@ -4366,9 +4372,9 @@
       }
     },
     "@dashevo/dashcore-lib": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/@dashevo/dashcore-lib/-/dashcore-lib-0.21.0.tgz",
-      "integrity": "sha512-pWrR1G/rgP+IfN59L005KeHEo+OKblkVNP8cC8GUrMkKKS7QrCNHi/F/DBb7zMcbo5NbIWJ1QYdK11Ya6nE3tQ==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@dashevo/dashcore-lib/-/dashcore-lib-0.21.1.tgz",
+      "integrity": "sha512-ZRzzvIkB5NtS04QmBDOPBqyMQTV+yzrUc/T+TbsKcF5FdapQCAzN4HnTsIXKLenPk2TpW/j68yFwoA1tj3eRXA==",
       "requires": {
         "@dashevo/bls": "~1.2.9",
         "@dashevo/x11-hash-js": "^1.0.2",
@@ -4385,19 +4391,19 @@
       }
     },
     "@dashevo/dashpay-contract": {
-      "version": "0.25.21",
-      "resolved": "https://registry.npmjs.org/@dashevo/dashpay-contract/-/dashpay-contract-0.25.21.tgz",
-      "integrity": "sha512-jsLgkGJoRu1EmWa+w0auEVYmW/acpLdr+um4KFdKZ/N74xmrL5w1nXU6FzHg8mgI8dfrmrcInKEoCDA16S1nJA=="
+      "version": "1.0.0-dev.5",
+      "resolved": "https://registry.npmjs.org/@dashevo/dashpay-contract/-/dashpay-contract-1.0.0-dev.5.tgz",
+      "integrity": "sha512-t/vw4fTxEV5To9r+XoRYVzn8VHkh9eeQTae2Y9wlDZ9RGrDUl6PFkov+idcwnE9RzXjhpYkICca8Wo1VtYKO8Q=="
     },
     "@dashevo/dpns-contract": {
-      "version": "0.25.21",
-      "resolved": "https://registry.npmjs.org/@dashevo/dpns-contract/-/dpns-contract-0.25.21.tgz",
-      "integrity": "sha512-iyRX7Lmzz60Tt3spDgIMmsA1yIVtHSrkEvBURPLzSW2umAkjNhvra0rGDmDSVpF3bVNhJDtoPrepXmT1wh8sEA=="
+      "version": "1.0.0-dev.5",
+      "resolved": "https://registry.npmjs.org/@dashevo/dpns-contract/-/dpns-contract-1.0.0-dev.5.tgz",
+      "integrity": "sha512-Lp4PuDbwh/4Z6ufAQUz4oZuCyxBeFGQLDT1kyUB5K8tNMcaceY+gZQUPR5g5AGngY9KV8Z86hPUgpZDRXhdW7g=="
     },
     "@dashevo/grpc-common": {
-      "version": "0.25.21",
-      "resolved": "https://registry.npmjs.org/@dashevo/grpc-common/-/grpc-common-0.25.21.tgz",
-      "integrity": "sha512-PKmzMK34bXyJshWd/IoNZv8fT+MxQciTlkVO1UPrGSGIODBIZlt8HA65He6qehujdp800hpUZX3l6w3Y+HAplw==",
+      "version": "1.0.0-dev.5",
+      "resolved": "https://registry.npmjs.org/@dashevo/grpc-common/-/grpc-common-1.0.0-dev.5.tgz",
+      "integrity": "sha512-j2lustteb7iIKqW3FiCWyyaL+5PRZSHczp8lWg+hPQkqQpsSHTpmtB2DsAaL9jHa9WW7TVzeGATXsRT8YcX+TA==",
       "requires": {
         "@dashevo/protobufjs": "6.10.5",
         "@grpc/grpc-js": "1.4.4",
@@ -4409,9 +4415,9 @@
       }
     },
     "@dashevo/masternode-reward-shares-contract": {
-      "version": "0.25.21",
-      "resolved": "https://registry.npmjs.org/@dashevo/masternode-reward-shares-contract/-/masternode-reward-shares-contract-0.25.21.tgz",
-      "integrity": "sha512-KgOMHjETtp6KaM0Dp/hi3G9RU7Nd0dxHOWDNJt/2lIO6d3eXHgsMqrTAjH5THHPWf11FOgD21f4AkaMstaTYCg=="
+      "version": "1.0.0-dev.5",
+      "resolved": "https://registry.npmjs.org/@dashevo/masternode-reward-shares-contract/-/masternode-reward-shares-contract-1.0.0-dev.5.tgz",
+      "integrity": "sha512-x0IJhpRW68XerAdz9d8yYGhar3UlRpOEJiZtr/1s2ep1HUPDJpA1nbQznrb4daWqEmRHTEROyCXsBE+i1hgoJQ=="
     },
     "@dashevo/protobufjs": {
       "version": "6.10.5",
@@ -4446,14 +4452,14 @@
       }
     },
     "@dashevo/wallet-lib": {
-      "version": "7.25.21",
-      "resolved": "https://registry.npmjs.org/@dashevo/wallet-lib/-/wallet-lib-7.25.21.tgz",
-      "integrity": "sha512-7H5E4plFwKSC8GqH7xiUg6UstyP8+ocIEhTKTjU4HURsu2Q7uUxL5sWL8Pxw3Unz1ZUQRMbiPKhxJBID9yQvxw==",
+      "version": "8.0.0-dev.5",
+      "resolved": "https://registry.npmjs.org/@dashevo/wallet-lib/-/wallet-lib-8.0.0-dev.5.tgz",
+      "integrity": "sha512-GyWRrB8dTM0FTnr2YsFkp8OUTfVTKWdCZxJLF083pOufubA/PvAdRwUTzR7wzi1vO6CEWGAwDitPqEKDD8VIVw==",
       "requires": {
-        "@dashevo/dapi-client": "0.25.21",
-        "@dashevo/dashcore-lib": "~0.21.0",
-        "@dashevo/grpc-common": "0.25.21",
-        "@dashevo/wasm-dpp": "0.25.21",
+        "@dashevo/dapi-client": "1.0.0-dev.5",
+        "@dashevo/dashcore-lib": "~0.21.1",
+        "@dashevo/grpc-common": "1.0.0-dev.5",
+        "@dashevo/wasm-dpp": "1.0.0-dev.5",
         "@yarnpkg/pnpify": "^4.0.0-rc.42",
         "cbor": "^8.0.0",
         "crypto-js": "^4.2.0",
@@ -4464,15 +4470,20 @@
       }
     },
     "@dashevo/wasm-dpp": {
-      "version": "0.25.21",
-      "resolved": "https://registry.npmjs.org/@dashevo/wasm-dpp/-/wasm-dpp-0.25.21.tgz",
-      "integrity": "sha512-BWiMLKfWP5vUVvo3LAaX5cckZ4e7VCt/DC3iBnsLMs0vQFFzn+IMS38MgSWOCQiQywWNeCdiAzKyyEQ9p7kv9A==",
+      "version": "1.0.0-dev.5",
+      "resolved": "https://registry.npmjs.org/@dashevo/wasm-dpp/-/wasm-dpp-1.0.0-dev.5.tgz",
+      "integrity": "sha512-w7KmU69t4hTjUymttvTaIRCBBGjEYuaXY488C1uEFuCLjdIlElDoJbjBR1CO2ltQqh9Fa+oBC1+z3WgX9Fa93w==",
       "requires": {
         "@dashevo/bls": "~1.2.9",
         "bs58": "^4.0.1",
         "lodash": "^4.17.21",
         "varint": "^6.0.0"
       }
+    },
+    "@dashevo/withdrawals-contract": {
+      "version": "1.0.0-dev.5",
+      "resolved": "https://registry.npmjs.org/@dashevo/withdrawals-contract/-/withdrawals-contract-1.0.0-dev.5.tgz",
+      "integrity": "sha512-2Mcu2fl3RFGYpZ8EvMz8Ia6JLmdLF3PlgFBaowFUKO6+aJpRCXMYoScBfQ/hFD4t6iAI4Sih7o1MB8pIz/ucSA=="
     },
     "@dashevo/x11-hash-js": {
       "version": "1.0.2",
@@ -4805,9 +4816,9 @@
       }
     },
     "@types/semver": {
-      "version": "7.5.6",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.6.tgz",
-      "integrity": "sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A=="
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.7.tgz",
+      "integrity": "sha512-/wdoPq1QqkSj9/QOeKkFquEuPzQbHTWAMPH/PaUMB+JuR31lXhlWXRZ52IpfDYVlDOUBvX09uBrPwxGT1hjNBg=="
     },
     "@types/treeify": {
       "version": "1.0.3",
@@ -4820,15 +4831,15 @@
       "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw=="
     },
     "@yarnpkg/core": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@yarnpkg/core/-/core-4.0.2.tgz",
-      "integrity": "sha512-YSibU3htZ3ZyslCUCG0aI4xcnmPZwZnHSUYl8TgC/Ck3++9xr474Mzh3t4Zv8olh9BguMC7FmRSpKAThiaFafw==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/core/-/core-4.0.3.tgz",
+      "integrity": "sha512-O+WGCjB9aIBxdRMBxXdsIy08MW4RbxfCS2AfywWb8DPS9H0LICahUJgNAaE0fwCsW7/gNzQbLYlh9DQQwzONrA==",
       "requires": {
         "@arcanis/slice-ansi": "^1.1.1",
         "@types/semver": "^7.1.0",
         "@types/treeify": "^1.0.0",
-        "@yarnpkg/fslib": "^3.0.1",
-        "@yarnpkg/libzip": "^3.0.0",
+        "@yarnpkg/fslib": "^3.0.2",
+        "@yarnpkg/libzip": "^3.0.1",
         "@yarnpkg/parsers": "^3.0.0",
         "@yarnpkg/shell": "^4.0.0",
         "camelcase": "^5.3.1",
@@ -4872,31 +4883,31 @@
       }
     },
     "@yarnpkg/fslib": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@yarnpkg/fslib/-/fslib-3.0.1.tgz",
-      "integrity": "sha512-TtodA4zcpKfMRI8iEBEGIRdwJ7uhj/ic2bDCBSdt6KU8WoLv9b91oqi6t37ttY7+c8B9z750W0PZHmQR3lpLNA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/fslib/-/fslib-3.0.2.tgz",
+      "integrity": "sha512-dqSpZCj9ZeqMZzITHvpi5qKS9MCLWZYCl6NHCSl3a+BqiyLApehWAy60zjv9F1fxKZ6RKDgHLhBWhx8RwPm6Dw==",
       "requires": {
         "tslib": "^2.4.0"
       }
     },
     "@yarnpkg/libzip": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@yarnpkg/libzip/-/libzip-3.0.0.tgz",
-      "integrity": "sha512-31NR8oHG/NLnSEqQOy48tnjNHgYPujOtammmvoItNAfsWAmaOqtDimwPRRPXGTNxC2SYYBYrk6pli5yti/Qmfw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/libzip/-/libzip-3.0.1.tgz",
+      "integrity": "sha512-fiqRLk2fyd2r34/Qc7HlP8fKIo1CK5CZpLNObJwnbFmZQN2hVanovFlG++3oH3qYJymEmjPl5EGsygcEJZl4Pg==",
       "requires": {
         "@types/emscripten": "^1.39.6",
-        "@yarnpkg/fslib": "^3.0.0",
+        "@yarnpkg/fslib": "^3.0.2",
         "tslib": "^2.4.0"
       }
     },
     "@yarnpkg/nm": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@yarnpkg/nm/-/nm-4.0.1.tgz",
-      "integrity": "sha512-JWWTfqKX4Sci8kgN9ozGjk3HQLAXsaTIlHQfu4r1hsaS9Lw75Q1DLTfak94qN7PhM9UzKDCQD2U53aXhzgPXgQ==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/nm/-/nm-4.0.2.tgz",
+      "integrity": "sha512-TcoNjsT1r2fnC3/3FivIssXH3ZIdn0s75j6dDNUG8e9AbDRj6pDSxKp6p5KbLQ2LrTM9Zv73gRqe7lYeagBoTg==",
       "requires": {
-        "@yarnpkg/core": "^4.0.2",
-        "@yarnpkg/fslib": "^3.0.1",
-        "@yarnpkg/pnp": "^4.0.1"
+        "@yarnpkg/core": "^4.0.3",
+        "@yarnpkg/fslib": "^3.0.2",
+        "@yarnpkg/pnp": "^4.0.2"
       }
     },
     "@yarnpkg/parsers": {
@@ -4909,18 +4920,18 @@
       }
     },
     "@yarnpkg/pnp": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@yarnpkg/pnp/-/pnp-4.0.1.tgz",
-      "integrity": "sha512-oxs80lP3qINsP2GjF/KvzIdhDUm45xwxWhYleLSDdRTGHdh5GiTghM6wXzfIbRJzb7R/jMCU4oGcLCSr+La4rw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/pnp/-/pnp-4.0.2.tgz",
+      "integrity": "sha512-fOZoZJP8AqHtAWlgZukbQu87lHtm2Hutz5EzahKx7756EfgkE3hcyp0PukYzO2GITPtgsNo5A0V4R1FgFJtAUA==",
       "requires": {
         "@types/node": "^18.17.15",
-        "@yarnpkg/fslib": "^3.0.1"
+        "@yarnpkg/fslib": "^3.0.2"
       },
       "dependencies": {
         "@types/node": {
-          "version": "18.19.6",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.6.tgz",
-          "integrity": "sha512-X36s5CXMrrJOs2lQCdDF68apW4Rfx9ixYMawlepwmE4Anezv/AV2LSpKD1Ub8DAc+urp5bk0BGZ6NtmBitfnsg==",
+          "version": "18.19.17",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.17.tgz",
+          "integrity": "sha512-SzyGKgwPzuWp2SHhlpXKzCX0pIOfcI4V2eF37nNBJOhwlegQ83omtVQ1XxZpDE06V/d6AQvfQdPfnw0tRC//Ng==",
           "requires": {
             "undici-types": "~5.26.4"
           }
@@ -5209,9 +5220,9 @@
       }
     },
     "clipanion": {
-      "version": "4.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/clipanion/-/clipanion-4.0.0-rc.2.tgz",
-      "integrity": "sha512-0IXugyri0bQs6/JLS9Uoh9xZ4kiDyFf6gAoikefPW/yHJZbS4We4jjx5HZPU/xfRjILSzZld9Q9P3JBJe6irUA==",
+      "version": "4.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/clipanion/-/clipanion-4.0.0-rc.3.tgz",
+      "integrity": "sha512-+rJOJMt2N6Oikgtfqmo/Duvme7uz3SIedL2b6ycgCztQMiTfr3aQh2DDyLHl+QUPClKMNpSg3gDJFvNQYIcq1g==",
       "requires": {
         "typanion": "^3.8.0"
       }
@@ -5336,20 +5347,21 @@
       "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
     },
     "dash": {
-      "version": "3.25.21",
-      "resolved": "https://registry.npmjs.org/dash/-/dash-3.25.21.tgz",
-      "integrity": "sha512-CELZkCupQs+GbwkYohwmZkGYIpK4HhUPEFfF722syowHy7AaFILMSwngG7VptSQq0I4OZdUzfRN3lIC4BKMzdQ==",
+      "version": "4.0.0-dev.5",
+      "resolved": "https://registry.npmjs.org/dash/-/dash-4.0.0-dev.5.tgz",
+      "integrity": "sha512-EB2TiGZY2EDWm8Yc4nFFWp41zk/SAM3zznsL56Gj7GAvyYUbTj1NxLU0Ja1nN7ETSgFVoe4+PXV77x5fB1OQ/A==",
       "requires": {
         "@dashevo/bls": "~1.2.9",
-        "@dashevo/dapi-client": "0.25.21",
-        "@dashevo/dapi-grpc": "0.25.21",
-        "@dashevo/dashcore-lib": "~0.21.0",
-        "@dashevo/dashpay-contract": "0.25.21",
-        "@dashevo/dpns-contract": "0.25.21",
-        "@dashevo/grpc-common": "0.25.21",
-        "@dashevo/masternode-reward-shares-contract": "0.25.21",
-        "@dashevo/wallet-lib": "7.25.21",
-        "@dashevo/wasm-dpp": "0.25.21",
+        "@dashevo/dapi-client": "1.0.0-dev.5",
+        "@dashevo/dapi-grpc": "1.0.0-dev.5",
+        "@dashevo/dashcore-lib": "~0.21.1",
+        "@dashevo/dashpay-contract": "1.0.0-dev.5",
+        "@dashevo/dpns-contract": "1.0.0-dev.5",
+        "@dashevo/grpc-common": "1.0.0-dev.5",
+        "@dashevo/masternode-reward-shares-contract": "1.0.0-dev.5",
+        "@dashevo/wallet-lib": "8.0.0-dev.5",
+        "@dashevo/wasm-dpp": "1.0.0-dev.5",
+        "@dashevo/withdrawals-contract": "1.0.0-dev.5",
         "bs58": "^4.0.1",
         "node-inspect-extracted": "^1.0.8",
         "winston": "^3.2.1"
@@ -5428,9 +5440,9 @@
       }
     },
     "diff": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
-      "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw=="
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
+      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A=="
     },
     "diff-sequences": {
       "version": "29.6.3",
@@ -5515,9 +5527,9 @@
       }
     },
     "escalade": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
+      "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA=="
     },
     "escape-string-regexp": {
       "version": "4.0.0",
@@ -5958,9 +5970,9 @@
       }
     },
     "hasown": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
-      "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.1.tgz",
+      "integrity": "sha512-1/th4MHjnwncwXsIW6QMzlvYL9kG5e/CpVvLRZe4XPa8TOUNbCELqmvhDmnkNsAjwaG4+I8gJJL0JBvTTLO9qA==",
       "requires": {
         "function-bind": "^1.1.2"
       }
@@ -6675,9 +6687,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "20.10.8",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.8.tgz",
-          "integrity": "sha512-f8nQs3cLxbAFc00vEU59yf9UyGUftkPaLGfvbVOIDdx2i1b8epBqj2aNGyP19fiyXWvlmZ7qC1XLjAzw/OKIeA==",
+          "version": "20.11.19",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.19.tgz",
+          "integrity": "sha512-7xMnVEcZFu0DikYjWOlRq7NTPETrm7teqUT2WkQjrTIkEgUyyGdWsj/Zg8bEJt5TNklzbPD1X3fqfsHw3SpapQ==",
           "requires": {
             "undici-types": "~5.26.4"
           }
@@ -6915,9 +6927,9 @@
       "integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g=="
     },
     "semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
       "requires": {
         "lru-cache": "^6.0.0"
       }
@@ -6979,9 +6991,9 @@
       }
     },
     "spdx-exceptions": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
-      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+      "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w=="
     },
     "spdx-expression-parse": {
       "version": "3.0.1",
@@ -6993,9 +7005,9 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.16",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.16.tgz",
-      "integrity": "sha512-eWN+LnM3GR6gPu35WxNgbGl8rmY1AEmoMDvL/QD6zYmPWgywxWqJWNdLGT+ke8dKNWrcYgYjPpG5gbTfghP8rw=="
+      "version": "3.0.17",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.17.tgz",
+      "integrity": "sha512-sh8PWc/ftMqAAdFiBu6Fy6JUOYjqDJBJvIhpfDMyHrr0Rbp5liZqd4TjtQ/RgfLjKFZb+LMx5hpml5qOWy0qvg=="
     },
     "sprintf-js": {
       "version": "1.0.3",
@@ -7254,9 +7266,9 @@
       }
     },
     "winston-transport": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.6.0.tgz",
-      "integrity": "sha512-wbBA9PbPAHxKiygo7ub7BYRiKxms0tpfU2ljtWzb3SjRjv5yl6Ozuy/TkXf00HTAt+Uylo3gSkNwzc4ME0wiIg==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.7.0.tgz",
+      "integrity": "sha512-ajBj65K5I7denzer2IYW6+2bNIVqLGDHqDw3Ow8Ohh+vdW+rv4MZ6eiDvHoKhfJFZ2auyN8byXieDDJ96ViONg==",
       "requires": {
         "logform": "^2.3.2",
         "readable-stream": "^3.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "platform-readme-tutorials",
-  "version": "0.25.21",
+  "version": "1.0.0-dev",
   "description": "Tutorial code for https://docs.dash.org/platform",
   "main": "connect.js",
   "scripts": {
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/dashpay/platform-tutorials#readme",
   "dependencies": {
-    "dash": "^3.25.21"
+    "dash": "^4.0.0-dev.5"
   },
   "devDependencies": {
     "dotenv": "^16.0.0",


### PR DESCRIPTION
Testnet has been updated so a newer version of the SDK is needed to use it.