### PR TITLE
refactor: extract client instantiation to module

### DIFF
--- a/1-Identities-and-Names/identity-register.js
+++ b/1-Identities-and-Names/identity-register.js
@@ -1,7 +1,7 @@
 // See https://docs.dash.org/projects/platform/en/stable/docs/tutorials/identities-and-names/register-an-identity.html
-const getClient = require('../getClient');
+const setupDashClient = require('../setupDashClient');
 
-const client = getClient();
+const client = setupDashClient();
 
 const createIdentity = async () => {
   return client.platform.identities.register();

--- a/1-Identities-and-Names/identity-register.js
+++ b/1-Identities-and-Names/identity-register.js
@@ -1,7 +1,7 @@
 // See https://docs.dash.org/projects/platform/en/stable/docs/tutorials/identities-and-names/register-an-identity.html
 const getClient = require('../getClient');
 
-const client = getClient('readWrite');
+const client = getClient();
 
 const createIdentity = async () => {
   return client.platform.identities.register();

--- a/1-Identities-and-Names/identity-register.js
+++ b/1-Identities-and-Names/identity-register.js
@@ -1,18 +1,7 @@
 // See https://docs.dash.org/projects/platform/en/stable/docs/tutorials/identities-and-names/register-an-identity.html
-const Dash = require('dash');
-const dotenv = require('dotenv');
-dotenv.config();
+const getClient = require('../getClient');
 
-const clientOpts = {
-  network: process.env.NETWORK,
-  wallet: {
-    mnemonic: process.env.MNEMONIC, // A Dash wallet mnemonic with testnet funds
-    unsafeOptions: {
-      skipSynchronizationBeforeHeight: process.env.SYNC_START_HEIGHT, // sync starting at this Core block height
-    },
-  },
-};
-const client = new Dash.Client(clientOpts);
+const client = getClient('readWrite');
 
 const createIdentity = async () => {
   return client.platform.identities.register();

--- a/1-Identities-and-Names/identity-retrieve-account-ids.js
+++ b/1-Identities-and-Names/identity-retrieve-account-ids.js
@@ -1,7 +1,7 @@
 // See https://docs.dash.org/projects/platform/en/stable/docs/tutorials/identities-and-names/retrieve-an-accounts-identities.html
-const getClient = require('../getClient');
+const setupDashClient = require('../setupDashClient');
 
-const client = getClient();
+const client = setupDashClient();
 
 const retrieveIdentityIds = async () => {
   const account = await client.getWalletAccount();

--- a/1-Identities-and-Names/identity-retrieve-account-ids.js
+++ b/1-Identities-and-Names/identity-retrieve-account-ids.js
@@ -1,17 +1,7 @@
 // See https://docs.dash.org/projects/platform/en/stable/docs/tutorials/identities-and-names/retrieve-an-accounts-identities.html
-const Dash = require('dash');
-const dotenv = require('dotenv');
-dotenv.config();
+const getClient = require('../getClient');
 
-const client = new Dash.Client({
-  network: process.env.NETWORK,
-  wallet: {
-    mnemonic: process.env.MNEMONIC, // A Dash wallet mnemonic with testnet funds
-    unsafeOptions: {
-      skipSynchronizationBeforeHeight: process.env.SYNC_START_HEIGHT, // sync starting at this Core block height
-    },
-  },
-});
+const client = getClient();
 
 const retrieveIdentityIds = async () => {
   const account = await client.getWalletAccount();

--- a/1-Identities-and-Names/identity-retrieve.js
+++ b/1-Identities-and-Names/identity-retrieve.js
@@ -1,7 +1,7 @@
 // See https://docs.dash.org/projects/platform/en/stable/docs/tutorials/identities-and-names/retrieve-an-identity.html
 const getClient = require('../getClient');
 
-const client = getClient('readOnly');
+const client = getClient();
 
 const retrieveIdentity = async () => {
   return client.platform.identities.get(process.env.IDENTITY_ID); // Your identity ID

--- a/1-Identities-and-Names/identity-retrieve.js
+++ b/1-Identities-and-Names/identity-retrieve.js
@@ -1,9 +1,7 @@
 // See https://docs.dash.org/projects/platform/en/stable/docs/tutorials/identities-and-names/retrieve-an-identity.html
-const Dash = require('dash');
-const dotenv = require('dotenv');
-dotenv.config();
+const getClient = require('../getClient');
 
-const client = new Dash.Client({ network: process.env.NETWORK });
+const client = getClient('readOnly');
 
 const retrieveIdentity = async () => {
   return client.platform.identities.get(process.env.IDENTITY_ID); // Your identity ID

--- a/1-Identities-and-Names/identity-retrieve.js
+++ b/1-Identities-and-Names/identity-retrieve.js
@@ -1,7 +1,7 @@
 // See https://docs.dash.org/projects/platform/en/stable/docs/tutorials/identities-and-names/retrieve-an-identity.html
-const getClient = require('../getClient');
+const setupDashClient = require('../setupDashClient');
 
-const client = getClient();
+const client = setupDashClient();
 
 const retrieveIdentity = async () => {
   return client.platform.identities.get(process.env.IDENTITY_ID); // Your identity ID

--- a/1-Identities-and-Names/identity-topup.js
+++ b/1-Identities-and-Names/identity-topup.js
@@ -1,18 +1,7 @@
 // See https://docs.dash.org/projects/platform/en/stable/docs/tutorials/identities-and-names/topup-an-identity-balance.html
-const Dash = require('dash');
-const dotenv = require('dotenv');
-dotenv.config();
+const getClient = require('../getClient');
 
-const clientOpts = {
-  network: process.env.NETWORK,
-  wallet: {
-    mnemonic: process.env.MNEMONIC, // A Dash wallet mnemonic with testnet funds
-    unsafeOptions: {
-      skipSynchronizationBeforeHeight: process.env.SYNC_START_HEIGHT, // sync starting at this Core block height
-    },
-  },
-};
-const client = new Dash.Client(clientOpts);
+const client = getClient();
 
 const topupIdentity = async () => {
   const identityId = process.env.IDENTITY_ID; // Your identity ID

--- a/1-Identities-and-Names/identity-topup.js
+++ b/1-Identities-and-Names/identity-topup.js
@@ -1,7 +1,7 @@
 // See https://docs.dash.org/projects/platform/en/stable/docs/tutorials/identities-and-names/topup-an-identity-balance.html
-const getClient = require('../getClient');
+const setupDashClient = require('../setupDashClient');
 
-const client = getClient();
+const client = setupDashClient();
 
 const topupIdentity = async () => {
   const identityId = process.env.IDENTITY_ID; // Your identity ID

--- a/1-Identities-and-Names/identity-transfer-credits.js
+++ b/1-Identities-and-Names/identity-transfer-credits.js
@@ -1,18 +1,7 @@
 // See https://docs.dash.org/projects/platform/en/stable/docs/tutorials/identities-and-names/transfer-credits-to-an-identity.html
-const Dash = require('dash');
-const dotenv = require('dotenv');
-dotenv.config();
+const getClient = require('../getClient');
 
-const clientOpts = {
-  network: process.env.NETWORK,
-  wallet: {
-    mnemonic: process.env.MNEMONIC, // A Dash wallet mnemonic with testnet funds
-    unsafeOptions: {
-      skipSynchronizationBeforeHeight: process.env.SYNC_START_HEIGHT, // only sync from mid-2023
-    },
-  },
-};
-const client = new Dash.Client(clientOpts);
+const client = getClient();
 
 const transferCredits = async () => {
   const identityId = process.env.IDENTITY_ID; // Your identity ID

--- a/1-Identities-and-Names/identity-transfer-credits.js
+++ b/1-Identities-and-Names/identity-transfer-credits.js
@@ -1,7 +1,7 @@
 // See https://docs.dash.org/projects/platform/en/stable/docs/tutorials/identities-and-names/transfer-credits-to-an-identity.html
-const getClient = require('../getClient');
+const setupDashClient = require('../setupDashClient');
 
-const client = getClient();
+const client = setupDashClient();
 
 const transferCredits = async () => {
   const identityId = process.env.IDENTITY_ID; // Your identity ID

--- a/1-Identities-and-Names/identity-update-add-key.js
+++ b/1-Identities-and-Names/identity-update-add-key.js
@@ -3,9 +3,9 @@ const Dash = require('dash');
 const {
   PlatformProtocol: { IdentityPublicKey, IdentityPublicKeyWithWitness },
 } = Dash;
-const getClient = require('../getClient');
+const setupDashClient = require('../setupDashClient');
 
-const client = getClient();
+const client = setupDashClient();
 
 const updateIdentityAddKey = async () => {
   const identityId = process.env.IDENTITY_ID;

--- a/1-Identities-and-Names/identity-update-add-key.js
+++ b/1-Identities-and-Names/identity-update-add-key.js
@@ -3,19 +3,9 @@ const Dash = require('dash');
 const {
   PlatformProtocol: { IdentityPublicKey, IdentityPublicKeyWithWitness },
 } = Dash;
-const dotenv = require('dotenv');
-dotenv.config();
+const getClient = require('../getClient');
 
-const clientOpts = {
-  network: process.env.NETWORK,
-  wallet: {
-    mnemonic: process.env.MNEMONIC, // A Dash wallet mnemonic with testnet funds
-    unsafeOptions: {
-      skipSynchronizationBeforeHeight: process.env.SYNC_START_HEIGHT, // sync starting at this Core block height
-    },
-  },
-};
-const client = new Dash.Client(clientOpts);
+const client = getClient();
 
 const updateIdentityAddKey = async () => {
   const identityId = process.env.IDENTITY_ID;

--- a/1-Identities-and-Names/identity-update-disable-key.js
+++ b/1-Identities-and-Names/identity-update-disable-key.js
@@ -1,22 +1,11 @@
 // See https://docs.dash.org/projects/platform/en/stable/docs/tutorials/identities-and-names/update-an-identity.html
-const Dash = require('dash');
-const dotenv = require('dotenv');
-dotenv.config();
+const getClient = require('../getClient');
 
-const clientOpts = {
-  network: process.env.NETWORK,
-  wallet: {
-    mnemonic: process.env.MNEMONIC, // A Dash wallet mnemonic with testnet funds
-    unsafeOptions: {
-      skipSynchronizationBeforeHeight: process.env.SYNC_START_HEIGHT, // sync starting at this Core block height
-    },
-  },
-};
-const client = new Dash.Client(clientOpts);
+const client = getClient();
 
 const updateIdentityDisableKey = async () => {
   const identityId = process.env.IDENTITY_ID;
-  const keyId = 2; // One of the identity's public key IDs
+  const keyId = 3; // One of the identity's public key IDs
 
   // Retrieve the identity to be updated and the public key to disable
   const existingIdentity = await client.platform.identities.get(identityId);

--- a/1-Identities-and-Names/identity-update-disable-key.js
+++ b/1-Identities-and-Names/identity-update-disable-key.js
@@ -1,7 +1,7 @@
 // See https://docs.dash.org/projects/platform/en/stable/docs/tutorials/identities-and-names/update-an-identity.html
-const getClient = require('../getClient');
+const setupDashClient = require('../setupDashClient');
 
-const client = getClient();
+const client = setupDashClient();
 
 const updateIdentityDisableKey = async () => {
   const identityId = process.env.IDENTITY_ID;

--- a/1-Identities-and-Names/name-register-alias.js
+++ b/1-Identities-and-Names/name-register-alias.js
@@ -1,7 +1,7 @@
 // See https://docs.dash.org/projects/platform/en/stable/docs/tutorials/identities-and-names/register-a-name-for-an-identity.html
-const getClient = require('../getClient');
+const setupDashClient = require('../setupDashClient');
 
-const client = getClient();
+const client = setupDashClient();
 
 const registerAlias = async () => {
   const platform = client.platform;

--- a/1-Identities-and-Names/name-register-alias.js
+++ b/1-Identities-and-Names/name-register-alias.js
@@ -1,20 +1,7 @@
 // See https://docs.dash.org/projects/platform/en/stable/docs/tutorials/identities-and-names/register-a-name-for-an-identity.html
-const Dash = require('dash');
-const dotenv = require('dotenv');
-dotenv.config();
+const getClient = require('../getClient');
 
-const aliasToRegister = ''; // Enter alias to register
-
-const clientOpts = {
-  network: process.env.NETWORK,
-  wallet: {
-    mnemonic: process.env.MNEMONIC, // A Dash wallet mnemonic with testnet funds
-    unsafeOptions: {
-      skipSynchronizationBeforeHeight: process.env.SYNC_START_HEIGHT, // sync starting at this Core block height
-    },
-  },
-};
-const client = new Dash.Client(clientOpts);
+const client = getClient();
 
 const registerAlias = async () => {
   const platform = client.platform;

--- a/1-Identities-and-Names/name-register.js
+++ b/1-Identities-and-Names/name-register.js
@@ -1,7 +1,7 @@
 // See https://docs.dash.org/projects/platform/en/stable/docs/tutorials/identities-and-names/register-a-name-for-an-identity.html
-const getClient = require('../getClient');
+const setupDashClient = require('../setupDashClient');
 
-const client = getClient();
+const client = setupDashClient();
 
 const registerName = async () => {
   const { platform } = client;

--- a/1-Identities-and-Names/name-register.js
+++ b/1-Identities-and-Names/name-register.js
@@ -1,20 +1,7 @@
 // See https://docs.dash.org/projects/platform/en/stable/docs/tutorials/identities-and-names/register-a-name-for-an-identity.html
-const Dash = require('dash');
-const dotenv = require('dotenv');
-dotenv.config();
+const getClient = require('../getClient');
 
-const nameToRegister = ''; // Enter name to register
-
-const clientOpts = {
-  network: process.env.NETWORK,
-  wallet: {
-    mnemonic: process.env.MNEMONIC, // A Dash wallet mnemonic with testnet funds
-    unsafeOptions: {
-      skipSynchronizationBeforeHeight: process.env.SYNC_START_HEIGHT, // sync starting at this Core block height
-    },
-  },
-};
-const client = new Dash.Client(clientOpts);
+const client = getClient();
 
 const registerName = async () => {
   const { platform } = client;

--- a/1-Identities-and-Names/name-resolve-by-name.js
+++ b/1-Identities-and-Names/name-resolve-by-name.js
@@ -1,7 +1,7 @@
 // See https://docs.dash.org/projects/platform/en/stable/docs/tutorials/identities-and-names/retrieve-a-name.html
-const getClient = require('../getClient');
+const setupDashClient = require('../setupDashClient');
 
-const client = getClient();
+const client = setupDashClient();
 
 const nameToRetrieve = ''; // Enter name to retrieve
 

--- a/1-Identities-and-Names/name-resolve-by-name.js
+++ b/1-Identities-and-Names/name-resolve-by-name.js
@@ -1,7 +1,7 @@
 // See https://docs.dash.org/projects/platform/en/stable/docs/tutorials/identities-and-names/retrieve-a-name.html
-const Dash = require('dash');
+const getClient = require('../getClient');
 
-const client = new Dash.Client({ network: process.env.NETWORK });
+const client = getClient();
 
 const nameToRetrieve = ''; // Enter name to retrieve
 

--- a/1-Identities-and-Names/name-resolve-by-record.js
+++ b/1-Identities-and-Names/name-resolve-by-record.js
@@ -1,7 +1,7 @@
 // See https://docs.dash.org/projects/platform/en/stable/docs/tutorials/identities-and-names/retrieve-a-name.html
-const getClient = require('../getClient');
+const setupDashClient = require('../setupDashClient');
 
-const client = getClient();
+const client = setupDashClient();
 
 const retrieveNameByRecord = async () => {
   // Retrieve by a name's identity ID

--- a/1-Identities-and-Names/name-resolve-by-record.js
+++ b/1-Identities-and-Names/name-resolve-by-record.js
@@ -1,9 +1,7 @@
 // See https://docs.dash.org/projects/platform/en/stable/docs/tutorials/identities-and-names/retrieve-a-name.html
-const Dash = require('dash');
-const dotenv = require('dotenv');
-dotenv.config();
+const getClient = require('../getClient');
 
-const client = new Dash.Client({ network: process.env.NETWORK });
+const client = getClient();
 
 const retrieveNameByRecord = async () => {
   // Retrieve by a name's identity ID

--- a/1-Identities-and-Names/name-search-by-name.js
+++ b/1-Identities-and-Names/name-search-by-name.js
@@ -1,11 +1,9 @@
 // See https://docs.dash.org/projects/platform/en/stable/docs/tutorials/identities-and-names/retrieve-a-name.html
-const Dash = require('dash');
-const dotenv = require('dotenv');
-dotenv.config();
+const getClient = require('../getClient');
 
 const searchPrefix = 'a'; // Enter prefix character(s) to search for
 
-const client = new Dash.Client({ network: process.env.NETWORK });
+const client = getClient();
 
 const retrieveNameBySearch = async () => {
   // Search for names (e.g. `user*`)

--- a/1-Identities-and-Names/name-search-by-name.js
+++ b/1-Identities-and-Names/name-search-by-name.js
@@ -1,9 +1,9 @@
 // See https://docs.dash.org/projects/platform/en/stable/docs/tutorials/identities-and-names/retrieve-a-name.html
-const getClient = require('../getClient');
+const setupDashClient = require('../setupDashClient');
 
 const searchPrefix = 'a'; // Enter prefix character(s) to search for
 
-const client = getClient();
+const client = setupDashClient();
 
 const retrieveNameBySearch = async () => {
   // Search for names (e.g. `user*`)

--- a/2-Contracts-and-Documents/contract-register-history.js
+++ b/2-Contracts-and-Documents/contract-register-history.js
@@ -1,18 +1,7 @@
 // See https://docs.dash.org/projects/platform/en/stable/docs/tutorials/contracts-and-documents/register-a-data-contract.html
-const Dash = require('dash');
-const dotenv = require('dotenv');
-dotenv.config();
+const getClient = require('../getClient');
 
-const clientOpts = {
-  network: process.env.NETWORK,
-  wallet: {
-    mnemonic: process.env.MNEMONIC, // A Dash wallet mnemonic with testnet funds
-    unsafeOptions: {
-      skipSynchronizationBeforeHeight: process.env.SYNC_START_HEIGHT, // sync starting at this Core block height
-    },
-  },
-};
-const client = new Dash.Client(clientOpts);
+const client = getClient();
 
 const registerContract = async () => {
   const { platform } = client;

--- a/2-Contracts-and-Documents/contract-register-history.js
+++ b/2-Contracts-and-Documents/contract-register-history.js
@@ -1,7 +1,7 @@
 // See https://docs.dash.org/projects/platform/en/stable/docs/tutorials/contracts-and-documents/register-a-data-contract.html
-const getClient = require('../getClient');
+const setupDashClient = require('../setupDashClient');
 
-const client = getClient();
+const client = setupDashClient();
 
 const registerContract = async () => {
   const { platform } = client;

--- a/2-Contracts-and-Documents/contract-register-minimal.js
+++ b/2-Contracts-and-Documents/contract-register-minimal.js
@@ -1,18 +1,7 @@
 // See https://docs.dash.org/projects/platform/en/stable/docs/tutorials/contracts-and-documents/register-a-data-contract.html
-const Dash = require('dash');
-const dotenv = require('dotenv');
-dotenv.config();
+const getClient = require('../getClient');
 
-const clientOpts = {
-  network: process.env.NETWORK,
-  wallet: {
-    mnemonic: process.env.MNEMONIC, // A Dash wallet mnemonic with testnet funds
-    unsafeOptions: {
-      skipSynchronizationBeforeHeight: process.env.SYNC_START_HEIGHT, // sync starting at this Core block height
-    },
-  },
-};
-const client = new Dash.Client(clientOpts);
+const client = getClient();
 
 const registerContract = async () => {
   const { platform } = client;

--- a/2-Contracts-and-Documents/contract-register-minimal.js
+++ b/2-Contracts-and-Documents/contract-register-minimal.js
@@ -1,7 +1,7 @@
 // See https://docs.dash.org/projects/platform/en/stable/docs/tutorials/contracts-and-documents/register-a-data-contract.html
-const getClient = require('../getClient');
+const setupDashClient = require('../setupDashClient');
 
-const client = getClient();
+const client = setupDashClient();
 
 const registerContract = async () => {
   const { platform } = client;

--- a/2-Contracts-and-Documents/contract-retrieve-history.js
+++ b/2-Contracts-and-Documents/contract-retrieve-history.js
@@ -1,7 +1,7 @@
 // See https://docs.dash.org/projects/platform/en/stable/docs/tutorials/contracts-and-documents/retrieve-data-contract-history.html
-const getClient = require('../getClient');
+const setupDashClient = require('../setupDashClient');
 
-const client = getClient();
+const client = setupDashClient();
 
 const retrieveContractHistory = async () => {
   const contractId = process.env.CONTRACT_ID; // Your contract ID

--- a/2-Contracts-and-Documents/contract-retrieve-history.js
+++ b/2-Contracts-and-Documents/contract-retrieve-history.js
@@ -1,9 +1,7 @@
 // See https://docs.dash.org/projects/platform/en/stable/docs/tutorials/contracts-and-documents/retrieve-data-contract-history.html
-const Dash = require('dash');
-const dotenv = require('dotenv');
-dotenv.config();
+const getClient = require('../getClient');
 
-const client = new Dash.Client({ network: process.env.NETWORK });
+const client = getClient();
 
 const retrieveContractHistory = async () => {
   const contractId = process.env.CONTRACT_ID; // Your contract ID

--- a/2-Contracts-and-Documents/contract-retrieve.js
+++ b/2-Contracts-and-Documents/contract-retrieve.js
@@ -1,7 +1,7 @@
 // See https://docs.dash.org/projects/platform/en/stable/docs/tutorials/contracts-and-documents/retrieve-a-data-contract.html
-const getClient = require('../getClient');
+const setupDashClient = require('../setupDashClient');
 
-const client = getClient();
+const client = setupDashClient();
 
 const retrieveContract = async () => {
   const contractId = process.env.CONTRACT_ID; // Your contract ID

--- a/2-Contracts-and-Documents/contract-retrieve.js
+++ b/2-Contracts-and-Documents/contract-retrieve.js
@@ -1,9 +1,7 @@
 // See https://docs.dash.org/projects/platform/en/stable/docs/tutorials/contracts-and-documents/retrieve-a-data-contract.html
-const Dash = require('dash');
-const dotenv = require('dotenv');
-dotenv.config();
+const getClient = require('../getClient');
 
-const client = new Dash.Client({ network: process.env.NETWORK });
+const client = getClient();
 
 const retrieveContract = async () => {
   const contractId = process.env.CONTRACT_ID; // Your contract ID

--- a/2-Contracts-and-Documents/contract-update-history.js
+++ b/2-Contracts-and-Documents/contract-update-history.js
@@ -1,18 +1,7 @@
 // See https://docs.dash.org/projects/platform/en/stable/docs/tutorials/contracts-and-documents/update-documents.html
-const Dash = require('dash');
-const dotenv = require('dotenv');
-dotenv.config();
+const getClient = require('../getClient');
 
-const clientOpts = {
-  network: process.env.NETWORK,
-  wallet: {
-    mnemonic: process.env.MNEMONIC, // A Dash wallet mnemonic with testnet funds
-    unsafeOptions: {
-      skipSynchronizationBeforeHeight: process.env.SYNC_START_HEIGHT, // sync starting at this Core block height
-    },
-  },
-};
-const client = new Dash.Client(clientOpts);
+const client = getClient();
 
 const updateContract = async () => {
   const { platform } = client;

--- a/2-Contracts-and-Documents/contract-update-history.js
+++ b/2-Contracts-and-Documents/contract-update-history.js
@@ -1,7 +1,7 @@
 // See https://docs.dash.org/projects/platform/en/stable/docs/tutorials/contracts-and-documents/update-documents.html
-const getClient = require('../getClient');
+const setupDashClient = require('../setupDashClient');
 
-const client = getClient();
+const client = setupDashClient();
 
 const updateContract = async () => {
   const { platform } = client;

--- a/2-Contracts-and-Documents/contract-update-minimal.js
+++ b/2-Contracts-and-Documents/contract-update-minimal.js
@@ -1,18 +1,7 @@
 // See https://docs.dash.org/projects/platform/en/stable/docs/tutorials/contracts-and-documents/update-documents.html
-const Dash = require('dash');
-const dotenv = require('dotenv');
-dotenv.config();
+const getClient = require('../getClient');
 
-const clientOpts = {
-  network: process.env.NETWORK,
-  wallet: {
-    mnemonic: process.env.MNEMONIC, // A Dash wallet mnemonic with testnet funds
-    unsafeOptions: {
-      skipSynchronizationBeforeHeight: process.env.SYNC_START_HEIGHT, // sync starting at this Core block height
-    },
-  },
-};
-const client = new Dash.Client(clientOpts);
+const client = getClient();
 
 const updateContract = async () => {
   const { platform } = client;

--- a/2-Contracts-and-Documents/contract-update-minimal.js
+++ b/2-Contracts-and-Documents/contract-update-minimal.js
@@ -1,7 +1,7 @@
 // See https://docs.dash.org/projects/platform/en/stable/docs/tutorials/contracts-and-documents/update-documents.html
-const getClient = require('../getClient');
+const setupDashClient = require('../setupDashClient');
 
-const client = getClient();
+const client = setupDashClient();
 
 const updateContract = async () => {
   const { platform } = client;

--- a/2-Contracts-and-Documents/document-delete.js
+++ b/2-Contracts-and-Documents/document-delete.js
@@ -1,7 +1,7 @@
 // See https://docs.dash.org/projects/platform/en/stable/docs/tutorials/contracts-and-documents/delete-documents.html
-const getClient = require('../getClient');
+const setupDashClient = require('../setupDashClient');
 
-const client = getClient();
+const client = setupDashClient();
 
 const deleteNoteDocument = async () => {
   const { platform } = client;

--- a/2-Contracts-and-Documents/document-delete.js
+++ b/2-Contracts-and-Documents/document-delete.js
@@ -1,23 +1,7 @@
 // See https://docs.dash.org/projects/platform/en/stable/docs/tutorials/contracts-and-documents/delete-documents.html
-const Dash = require('dash');
-const dotenv = require('dotenv');
-dotenv.config();
+const getClient = require('../getClient');
 
-const clientOpts = {
-  network: process.env.NETWORK,
-  wallet: {
-    mnemonic: process.env.MNEMONIC, // A Dash wallet mnemonic with testnet funds
-    unsafeOptions: {
-      skipSynchronizationBeforeHeight: process.env.SYNC_START_HEIGHT, // sync starting at this Core block height
-    },
-  },
-  apps: {
-    tutorialContract: {
-      contractId: process.env.CONTRACT_ID, // Your contract ID
-    },
-  },
-};
-const client = new Dash.Client(clientOpts);
+const client = getClient();
 
 const deleteNoteDocument = async () => {
   const { platform } = client;

--- a/2-Contracts-and-Documents/document-retrieve.js
+++ b/2-Contracts-and-Documents/document-retrieve.js
@@ -1,7 +1,7 @@
 // See https://docs.dash.org/projects/platform/en/stable/docs/tutorials/contracts-and-documents/retrieve-documents.html
-const getClient = require('../getClient');
+const setupDashClient = require('../setupDashClient');
 
-const client = getClient();
+const client = setupDashClient();
 
 const getDocuments = async () => {
   return client.platform.documents.get('tutorialContract.note', {

--- a/2-Contracts-and-Documents/document-retrieve.js
+++ b/2-Contracts-and-Documents/document-retrieve.js
@@ -1,17 +1,7 @@
 // See https://docs.dash.org/projects/platform/en/stable/docs/tutorials/contracts-and-documents/retrieve-documents.html
-const Dash = require('dash');
-const dotenv = require('dotenv');
-dotenv.config();
+const getClient = require('../getClient');
 
-const clientOpts = {
-  network: process.env.NETWORK,
-  apps: {
-    tutorialContract: {
-      contractId: process.env.CONTRACT_ID, // Your contract ID
-    },
-  },
-};
-const client = new Dash.Client(clientOpts);
+const client = getClient();
 
 const getDocuments = async () => {
   return client.platform.documents.get('tutorialContract.note', {

--- a/2-Contracts-and-Documents/document-submit.js
+++ b/2-Contracts-and-Documents/document-submit.js
@@ -1,23 +1,7 @@
 // See https://docs.dash.org/projects/platform/en/stable/docs/tutorials/contracts-and-documents/submit-documents.html
-const Dash = require('dash');
-const dotenv = require('dotenv');
-dotenv.config();
+const getClient = require('../getClient');
 
-const clientOpts = {
-  network: process.env.NETWORK,
-  wallet: {
-    mnemonic: process.env.MNEMONIC, // A Dash wallet mnemonic with testnet funds
-    unsafeOptions: {
-      skipSynchronizationBeforeHeight: process.env.SYNC_START_HEIGHT, // sync starting at this Core block height
-    },
-  },
-  apps: {
-    tutorialContract: {
-      contractId: process.env.CONTRACT_ID, // Your contract ID
-    },
-  },
-};
-const client = new Dash.Client(clientOpts);
+const client = getClient();
 
 const submitNoteDocument = async () => {
   const { platform } = client;

--- a/2-Contracts-and-Documents/document-submit.js
+++ b/2-Contracts-and-Documents/document-submit.js
@@ -1,7 +1,7 @@
 // See https://docs.dash.org/projects/platform/en/stable/docs/tutorials/contracts-and-documents/submit-documents.html
-const getClient = require('../getClient');
+const setupDashClient = require('../setupDashClient');
 
-const client = getClient();
+const client = setupDashClient();
 
 const submitNoteDocument = async () => {
   const { platform } = client;

--- a/2-Contracts-and-Documents/document-update.js
+++ b/2-Contracts-and-Documents/document-update.js
@@ -1,7 +1,7 @@
 // See https://docs.dash.org/projects/platform/en/stable/docs/tutorials/contracts-and-documents/update-documents.html
-const getClient = require('../getClient');
+const setupDashClient = require('../setupDashClient');
 
-const client = getClient();
+const client = setupDashClient();
 
 const updateNoteDocument = async () => {
   const { platform } = client;

--- a/2-Contracts-and-Documents/document-update.js
+++ b/2-Contracts-and-Documents/document-update.js
@@ -1,23 +1,7 @@
 // See https://docs.dash.org/projects/platform/en/stable/docs/tutorials/contracts-and-documents/update-documents.html
-const Dash = require('dash');
-const dotenv = require('dotenv');
-dotenv.config();
+const getClient = require('../getClient');
 
-const clientOpts = {
-  network: process.env.NETWORK,
-  wallet: {
-    mnemonic: process.env.MNEMONIC, // A Dash wallet mnemonic with testnet funds
-    unsafeOptions: {
-      skipSynchronizationBeforeHeight: 875000, // only sync from mid-2023
-    },
-  },
-  apps: {
-    tutorialContract: {
-      contractId: process.env.CONTRACT_ID, // Your contract ID
-    },
-  },
-};
-const client = new Dash.Client(clientOpts);
+const client = getClient();
 
 const updateNoteDocument = async () => {
   const { platform } = client;

--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ Proceed with the tutorials
 [Contracts And Documents tutorials](./2-Contracts-and-Documents/) next. They
 align with the tutorials section found on the
 [documentation site](https://dashplatform.readme.io/docs/tutorials-introduction).
+Many client configuration options are included as comments in
+[`setupDashClient.js`](./setupDashClient.js) if more advanced configuration is
+required.
 
 After [creating an identity](./1-Identities-and-Names/identity-register.js), set
 the `IDENTITY_ID` value in your `.env` file to your new identity ID. After

--- a/connect.js
+++ b/connect.js
@@ -1,9 +1,8 @@
 // See https://dashplatform.readme.io/docs/tutorial-connecting-to-testnet
-const Dash = require('dash');
-const dotenv = require('dotenv');
-dotenv.config();
 
-const client = new Dash.Client({ network: process.env.NETWORK });
+const setupDashClient = require('./setupDashClient');
+
+const client = setupDashClient();
 
 async function connect() {
   return await client.getDAPIClient().core.getBestBlockHash();

--- a/getClient.js
+++ b/getClient.js
@@ -26,10 +26,10 @@ const clientOptions = {
   },
 
   // Configuration for Dash Platform applications
-  apps: {
-    // dpns: { contractId: 'yourDpnsContractId' },
-    // yourApp: { contractId: 'yourCustomAppContractId' },
-  },
+  // apps: {
+  //   dpns: { contractId: 'yourDpnsContractId' },
+  //   yourApp: { contractId: 'yourCustomAppContractId' },
+  // },
 
   // Custom list of DAPI seed nodes to connect to. Overrides the default seed list.
   // Format: { service: 'ip|domain:port' }

--- a/getClient.js
+++ b/getClient.js
@@ -15,7 +15,10 @@ const clientOptions = {
     // Unsafe wallet options (use with caution)
     unsafeOptions: {
       // Starting synchronization from a specific block height can speed up the initial wallet sync process.
-      skipSynchronizationBeforeHeight: parseInt(process.env.SYNC_START_HEIGHT, 10),
+      skipSynchronizationBeforeHeight: parseInt(
+        process.env.SYNC_START_HEIGHT,
+        10,
+      ),
     },
 
     // The default account index to use for transactions and queries. Default is 0.
@@ -55,7 +58,11 @@ const clientOptions = {
 const getClient = () => {
   // Ensure that numeric values from environment variables are properly converted to numbers
   if (clientOptions.wallet?.unsafeOptions?.skipSynchronizationBeforeHeight) {
-    clientOptions.wallet.unsafeOptions.skipSynchronizationBeforeHeight = parseInt(clientOptions.wallet.unsafeOptions.skipSynchronizationBeforeHeight, 10);
+    clientOptions.wallet.unsafeOptions.skipSynchronizationBeforeHeight =
+      parseInt(
+        clientOptions.wallet.unsafeOptions.skipSynchronizationBeforeHeight,
+        10,
+      );
   }
 
   return new Dash.Client(clientOptions);

--- a/getClient.js
+++ b/getClient.js
@@ -2,33 +2,63 @@ const Dash = require('dash');
 const dotenv = require('dotenv');
 dotenv.config();
 
-// Define client options for different types
+// Fully configured client options
 const clientOptions = {
-  readWrite: {
-    network: process.env.NETWORK,
-    wallet: {
-      mnemonic: process.env.MNEMONIC,
-      unsafeOptions: {
-        skipSynchronizationBeforeHeight: process.env.SYNC_START_HEIGHT, // sync starting at this Core block height
-      },    
+  // The network to connect to ('testnet' or 'mainnet')
+  network: process.env.NETWORK,
+
+  // Wallet configuration for transactions and account management
+  wallet: {
+    // The mnemonic (seed phrase) for the wallet. Required for signing transactions.
+    mnemonic: process.env.MNEMONIC,
+
+    // Unsafe wallet options (use with caution)
+    unsafeOptions: {
+      // Starting synchronization from a specific block height can speed up the initial wallet sync process.
+      skipSynchronizationBeforeHeight: parseInt(process.env.SYNC_START_HEIGHT, 10),
     },
+
+    // The default account index to use for transactions and queries. Default is 0.
+    // defaultAccountIndex: 0,
   },
-  readOnly: {
-    network: process.env.NETWORK,
-    // No wallet options required for the read-only client
+
+  // Configuration for Dash Platform applications
+  apps: {
+    // dpns: { contractId: 'yourDpnsContractId' },
+    // yourApp: { contractId: 'yourCustomAppContractId' },
   },
+
+  // Custom list of DAPI seed nodes to connect to. Overrides the default seed list.
+  // Format: { service: 'ip|domain:port' }
+  // seeds: [
+  //   { host: 'seed-1.testnet.networks.dash.org:1443' }
+  // ],
+
+  // Custom list of DAPI addresses to connect to
+  // Format: [ 'ip:port' }
+  // dapiAddresses: [ '127.0.0.1:3000' ],
+
+  // Request timeout in milliseconds for DAPI calls
+  // timeout: 3000,
+
+  // The number of retries for a failed DAPI request before giving up
+  // retries: 5,
+
+  // The base ban time in milliseconds for a DAPI node that fails to respond properly
+  // baseBanTime: 120000,
 };
 
 /**
- * Creates and returns a Dash client instance based on the specified type.
- * @param {String} type The type of client to create ('readWrite' or 'readOnly').
+ * Creates and returns a Dash client instance
  * @returns {Dash.Client} The Dash client instance.
  */
-const getClient = (type = 'readWrite') => {
-  if (!clientOptions[type]) {
-    throw new Error(`Unsupported client type: ${type}`);
+const getClient = () => {
+  // Ensure that numeric values from environment variables are properly converted to numbers
+  if (clientOptions.wallet?.unsafeOptions?.skipSynchronizationBeforeHeight) {
+    clientOptions.wallet.unsafeOptions.skipSynchronizationBeforeHeight = parseInt(clientOptions.wallet.unsafeOptions.skipSynchronizationBeforeHeight, 10);
   }
-  return new Dash.Client(clientOptions[type]);
+
+  return new Dash.Client(clientOptions);
 };
 
 module.exports = getClient;

--- a/getClient.js
+++ b/getClient.js
@@ -1,0 +1,34 @@
+const Dash = require('dash');
+const dotenv = require('dotenv');
+dotenv.config();
+
+// Define client options for different types
+const clientOptions = {
+  readWrite: {
+    network: process.env.NETWORK,
+    wallet: {
+      mnemonic: process.env.MNEMONIC,
+      unsafeOptions: {
+        skipSynchronizationBeforeHeight: process.env.SYNC_START_HEIGHT, // sync starting at this Core block height
+      },    
+    },
+  },
+  readOnly: {
+    network: process.env.NETWORK,
+    // No wallet options required for the read-only client
+  },
+};
+
+/**
+ * Creates and returns a Dash client instance based on the specified type.
+ * @param {String} type The type of client to create ('readWrite' or 'readOnly').
+ * @returns {Dash.Client} The Dash client instance.
+ */
+const getClient = (type = 'readWrite') => {
+  if (!clientOptions[type]) {
+    throw new Error(`Unsupported client type: ${type}`);
+  }
+  return new Dash.Client(clientOptions[type]);
+};
+
+module.exports = getClient;

--- a/getClient.js
+++ b/getClient.js
@@ -26,10 +26,12 @@ const clientOptions = {
   },
 
   // Configuration for Dash Platform applications
-  // apps: {
-  //   dpns: { contractId: 'yourDpnsContractId' },
-  //   yourApp: { contractId: 'yourCustomAppContractId' },
-  // },
+  apps: {
+    // yourApp: { contractId: 'yourCustomAppContractId' },
+    tutorialContract: {
+      contractId: process.env.CONTRACT_ID, // Your contract ID
+    },
+},
 
   // Custom list of DAPI seed nodes to connect to. Overrides the default seed list.
   // Format: { service: 'ip|domain:port' }

--- a/send-funds.js
+++ b/send-funds.js
@@ -1,18 +1,8 @@
 // See https://docs.dash.org/projects/platform/en/stable/docs/tutorials/send-funds.html
-const Dash = require('dash');
-const dotenv = require('dotenv');
-dotenv.config();
 
-const clientOpts = {
-  network: process.env.NETWORK,
-  wallet: {
-    mnemonic: process.env.MNEMONIC, // A Dash wallet mnemonic with testnet funds
-    unsafeOptions: {
-      skipSynchronizationBeforeHeight: process.env.SYNC_START_HEIGHT, // sync starting at this Core block height
-    },
-  },
-};
-const client = new Dash.Client(clientOpts);
+const setupDashClient = require('./setupDashClient');
+
+const client = setupDashClient();
 
 const sendFunds = async () => {
   const account = await client.getWalletAccount();

--- a/setupDashClient.js
+++ b/setupDashClient.js
@@ -66,6 +66,7 @@ const setupDashClient = () => {
         10,
       );
   }
+  // console.dir(clientOptions);
   return new Dash.Client(clientOptions);
 };
 

--- a/setupDashClient.js
+++ b/setupDashClient.js
@@ -31,7 +31,7 @@ const clientOptions = {
     tutorialContract: {
       contractId: process.env.CONTRACT_ID, // Your contract ID
     },
-},
+  },
 
   // Custom list of DAPI seed nodes to connect to. Overrides the default seed list.
   // Format: { service: 'ip|domain:port' }

--- a/setupDashClient.js
+++ b/setupDashClient.js
@@ -57,7 +57,7 @@ const clientOptions = {
  * Creates and returns a Dash client instance
  * @returns {Dash.Client} The Dash client instance.
  */
-const getClient = () => {
+const setupDashClient = () => {
   // Ensure that numeric values from environment variables are properly converted to numbers
   if (clientOptions.wallet?.unsafeOptions?.skipSynchronizationBeforeHeight) {
     clientOptions.wallet.unsafeOptions.skipSynchronizationBeforeHeight =
@@ -66,8 +66,7 @@ const getClient = () => {
         10,
       );
   }
-
   return new Dash.Client(clientOptions);
 };
 
-module.exports = getClient;
+module.exports = setupDashClient;

--- a/use-dapi-client-methods.js
+++ b/use-dapi-client-methods.js
@@ -1,9 +1,8 @@
 // See https://dashplatform.readme.io/docs/tutorial-use-dapi-client-methods
-const Dash = require('dash');
-const dotenv = require('dotenv');
-dotenv.config();
 
-const client = new Dash.Client({ network: process.env.NETWORK });
+const setupDashClient = require('./setupDashClient');
+
+const client = setupDashClient();
 
 async function dapiClientMethods() {
   console.log(await client.getDAPIClient().core.getBlockHash(1));


### PR DESCRIPTION
Client instantiation is now handled outside the individual tutorials. This both cuts down on the amount of code present in each tutorial and makes it easy to modify client options. Many of the SDK client options are also provided (commented out) in the new `setupDashClient` module.

See #35 for background discussion. A PR will also be required in [dashpay/docs-platform](https://github.com/dashpay/docs-platform) to align the docs with this change.