### PR TITLE
chore: update dependencies and fix name-related logic

### DIFF
--- a/1-Identities-and-Names/identity-topup.js
+++ b/1-Identities-and-Names/identity-topup.js
@@ -5,7 +5,7 @@ const client = setupDashClient();
 
 const topupIdentity = async () => {
   const identityId = process.env.IDENTITY_ID; // Your identity ID
-  const topUpAmount = 100000; // Number of duffs
+  const topUpAmount = 300000; // Number of duffs
 
   await client.platform.identities.topUp(identityId, topUpAmount);
   return client.platform.identities.get(identityId);

--- a/1-Identities-and-Names/identity-update-disable-key.js
+++ b/1-Identities-and-Names/identity-update-disable-key.js
@@ -5,7 +5,7 @@ const client = setupDashClient();
 
 const updateIdentityDisableKey = async () => {
   const identityId = process.env.IDENTITY_ID;
-  const keyId = 3; // One of the identity's public key IDs
+  const keyId = 4; // One of the identity's public key IDs
 
   // Retrieve the identity to be updated and the public key to disable
   const existingIdentity = await client.platform.identities.get(identityId);

--- a/1-Identities-and-Names/name-register.js
+++ b/1-Identities-and-Names/name-register.js
@@ -9,7 +9,7 @@ const registerName = async () => {
   const identity = await platform.identities.get(process.env.IDENTITY_ID); // Your identity ID
   const nameRegistration = await platform.names.register(
     `${nameToRegister}.dash`,
-    { dashUniqueIdentityId: identity.getId() },
+    { identity: identity.getId() },
     identity,
   );
 

--- a/1-Identities-and-Names/name-resolve-by-record.js
+++ b/1-Identities-and-Names/name-resolve-by-record.js
@@ -6,7 +6,7 @@ const client = setupDashClient();
 const retrieveNameByRecord = async () => {
   // Retrieve by a name's identity ID
   return client.platform.names.resolveByRecord(
-    'dashUniqueIdentityId',
+    'identity',
     process.env.IDENTITY_ID, // Your identity ID
   );
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "platform-readme-tutorials",
-  "version": "1.0.0-beta",
+  "version": "1.1-dev",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "platform-readme-tutorials",
-      "version": "1.0.0-beta",
+      "version": "1.1-dev",
       "license": "MIT",
       "dependencies": {
-        "dash": "^4.0.0-beta.4"
+        "dash": "~4.1.0-dev"
       },
       "devDependencies": {
         "dotenv": "^16.0.0",
@@ -158,15 +158,15 @@
       }
     },
     "node_modules/@dashevo/dapi-client": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@dashevo/dapi-client/-/dapi-client-1.0.0-beta.4.tgz",
-      "integrity": "sha512-wUAlXGdFxUG9ZY1UmTTwwN5JVcf0c0oCCODUJzOlz/M+9HjAXz01OAFhaT/mWggHRtVpvY4shSh4/WS03Qge1w==",
+      "version": "1.1.0-pr.1713.2",
+      "resolved": "https://registry.npmjs.org/@dashevo/dapi-client/-/dapi-client-1.1.0-pr.1713.2.tgz",
+      "integrity": "sha512-2Y/E3DZKfCNGaFgH8eonT2ih2JlgszRga9fRqthL9+Soukor31SM9mCYFiIkfES9e44DtO0YyaCSXDiFjyYU0g==",
       "dependencies": {
-        "@dashevo/dapi-grpc": "1.0.0-beta.4",
-        "@dashevo/dash-spv": "1.0.0-beta.4",
+        "@dashevo/dapi-grpc": "1.1.0-pr.1713.2",
+        "@dashevo/dash-spv": "2.1.0-pr.1713.2",
         "@dashevo/dashcore-lib": "~0.21.3",
-        "@dashevo/grpc-common": "1.0.0-beta.4",
-        "@dashevo/wasm-dpp": "1.0.0-beta.4",
+        "@dashevo/grpc-common": "1.1.0-pr.1713.2",
+        "@dashevo/wasm-dpp": "1.1.0-pr.1713.2",
         "bs58": "^4.0.1",
         "cbor": "^8.0.0",
         "google-protobuf": "^3.12.2",
@@ -178,11 +178,11 @@
       }
     },
     "node_modules/@dashevo/dapi-grpc": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@dashevo/dapi-grpc/-/dapi-grpc-1.0.0-beta.4.tgz",
-      "integrity": "sha512-THmMUJ8enBgE6FyGP+lpSgx0Ii6JCx4d1CSlLyu2eryFMAfxIcScfF3DEvRR4QbvzgRRC+J9wYZZIAYo7hWbrg==",
+      "version": "1.1.0-pr.1713.2",
+      "resolved": "https://registry.npmjs.org/@dashevo/dapi-grpc/-/dapi-grpc-1.1.0-pr.1713.2.tgz",
+      "integrity": "sha512-bpxyOZ7tXXWFzYHQ5jjJBlt4VHsbhIyiDHEqBk4mBrHtkELfS2KmEYvfwn2dFUc9B1ryQUxmZewtgOaEOy3Nmw==",
       "dependencies": {
-        "@dashevo/grpc-common": "1.0.0-beta.4",
+        "@dashevo/grpc-common": "1.1.0-pr.1713.2",
         "@dashevo/protobufjs": "6.10.5",
         "@grpc/grpc-js": "1.4.4",
         "@improbable-eng/grpc-web": "^0.15.0",
@@ -196,9 +196,9 @@
       "integrity": "sha512-rt0PzGzqplqERWVIMLlBxm4mJqjFTYNUFRhIccbfaF/MDyd0/585krGOWIhe0Sis9XQNA/FJlxxRjtPXIcyyCg=="
     },
     "node_modules/@dashevo/dash-spv": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@dashevo/dash-spv/-/dash-spv-1.0.0-beta.4.tgz",
-      "integrity": "sha512-cdnrMom24/68ihMljEKalYv5gmcNCmZAmMC3fHEpClQc75CJdQm2sRkRPBfZxlxMFD8eaiUyXIUUE3cdqGN1ig==",
+      "version": "2.1.0-pr.1713.2",
+      "resolved": "https://registry.npmjs.org/@dashevo/dash-spv/-/dash-spv-2.1.0-pr.1713.2.tgz",
+      "integrity": "sha512-vXT9nAJG2l6W1E16RtCMRNJ9RUl/dXUQA/TdYxyAwBDgLyO+MB4yLXcgV8jRC1WFtuVL5i0QcmurOETGamXbPQ==",
       "dependencies": {
         "@dashevo/dark-gravity-wave": "^1.1.1",
         "@dashevo/dash-util": "^2.0.3",
@@ -237,19 +237,19 @@
       }
     },
     "node_modules/@dashevo/dashpay-contract": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@dashevo/dashpay-contract/-/dashpay-contract-1.0.0-beta.4.tgz",
-      "integrity": "sha512-77CsG8MvCMAHU+ee8DABzzyvwA9ZBeB1wFwnaTOvQdg8vzs4p1q8Ni7b7oCCOl+ZHtWDckoDxFQrWBV10TzxCQ=="
+      "version": "1.1.0-pr.1713.2",
+      "resolved": "https://registry.npmjs.org/@dashevo/dashpay-contract/-/dashpay-contract-1.1.0-pr.1713.2.tgz",
+      "integrity": "sha512-9RAbTM/88QWZJbCUXqSthnFIZlfM4r93iZmLDWnVq+z+yCgxTe7TYBeq/IbgoAwRmsEh1TlGJUFxYFg/LY3J4w=="
     },
     "node_modules/@dashevo/dpns-contract": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@dashevo/dpns-contract/-/dpns-contract-1.0.0-beta.4.tgz",
-      "integrity": "sha512-epyIlAR2DqoBY0xxlNv3HfpkZkFS2tAQDW4S/MfNNpDM1CGgqyVDIJj1jGbOPybWA+BPrsTtyLJolVtBYO50MQ=="
+      "version": "1.1.0-pr.1713.2",
+      "resolved": "https://registry.npmjs.org/@dashevo/dpns-contract/-/dpns-contract-1.1.0-pr.1713.2.tgz",
+      "integrity": "sha512-gBAUqUq7a/P0CNWNOsk71IdWCmZUnPQcxv/WrnS4t+FVXTDnE3RSbTPS6sEabIIF1dw/PtAGMKGDFmnBpQ2IUA=="
     },
     "node_modules/@dashevo/grpc-common": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@dashevo/grpc-common/-/grpc-common-1.0.0-beta.4.tgz",
-      "integrity": "sha512-mbJDNSqQsOhcTr6xfur8ehldY8BVdVdP1cp83srA7d6cPcnUBKvAPeZM4LpFzQ8npQS3i2xvNFL2vqv4Y09cUg==",
+      "version": "1.1.0-pr.1713.2",
+      "resolved": "https://registry.npmjs.org/@dashevo/grpc-common/-/grpc-common-1.1.0-pr.1713.2.tgz",
+      "integrity": "sha512-mfOP4OXKxSWoKDgKxShP1PAlCzXPh7GPCjVGw1zPpvxBe2G/CBqPN01MjHe6uxbJzYRgKcxVez/Ov5+7g9GVLA==",
       "dependencies": {
         "@dashevo/protobufjs": "6.10.5",
         "@grpc/grpc-js": "1.4.4",
@@ -261,9 +261,9 @@
       }
     },
     "node_modules/@dashevo/masternode-reward-shares-contract": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@dashevo/masternode-reward-shares-contract/-/masternode-reward-shares-contract-1.0.0-beta.4.tgz",
-      "integrity": "sha512-i4QEmyamBCl7ZfD0T7LhnNskgARNPMnJw5buGLJ0waj8tzhzT7nMMzASBRrlOaK2xy15Y3JUtjh8ma2/fT8Yuw=="
+      "version": "1.1.0-pr.1713.2",
+      "resolved": "https://registry.npmjs.org/@dashevo/masternode-reward-shares-contract/-/masternode-reward-shares-contract-1.1.0-pr.1713.2.tgz",
+      "integrity": "sha512-MduiOsZOb9BuHhTy+zhgkGxU8nGbb5TJHDKXu+aphos3puV0nyFE/0M2AAXazyeCqCzdzBhfbzdi9Ur6R9Yjbg=="
     },
     "node_modules/@dashevo/protobufjs": {
       "version": "6.10.5",
@@ -301,14 +301,14 @@
       "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
     },
     "node_modules/@dashevo/wallet-lib": {
-      "version": "8.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@dashevo/wallet-lib/-/wallet-lib-8.0.0-beta.4.tgz",
-      "integrity": "sha512-0E5i8KVB61+HKJ2VXRVZUcRxPs+vERRTcCTEtofQgOg/RUaAmLT9U66xNJ729BM5elX/aShy0MWTPqm8sAZRHw==",
+      "version": "8.1.0-pr.1713.2",
+      "resolved": "https://registry.npmjs.org/@dashevo/wallet-lib/-/wallet-lib-8.1.0-pr.1713.2.tgz",
+      "integrity": "sha512-xi1+4sk0eUpW0y1/+nAkwP3BjHLT+SpiSmqkV5DCdarYVsbLElYkGStxhHpGt4pqP1zEkTL8Ru9dhBXgNkdIPQ==",
       "dependencies": {
-        "@dashevo/dapi-client": "1.0.0-beta.4",
+        "@dashevo/dapi-client": "1.1.0-pr.1713.2",
         "@dashevo/dashcore-lib": "~0.21.3",
-        "@dashevo/grpc-common": "1.0.0-beta.4",
-        "@dashevo/wasm-dpp": "1.0.0-beta.4",
+        "@dashevo/grpc-common": "1.1.0-pr.1713.2",
+        "@dashevo/wasm-dpp": "1.1.0-pr.1713.2",
         "@yarnpkg/pnpify": "^4.0.0-rc.42",
         "cbor": "^8.0.0",
         "crypto-js": "^4.2.0",
@@ -319,9 +319,9 @@
       }
     },
     "node_modules/@dashevo/wasm-dpp": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@dashevo/wasm-dpp/-/wasm-dpp-1.0.0-beta.4.tgz",
-      "integrity": "sha512-WyctJC6JTO4HM+9bCss97MEBtckawB9QWOVvErSY7Oqu2J/oRcc1LVYBtT8rMnANw+IC4mHqAMaQVOkgz9y2fw==",
+      "version": "1.1.0-pr.1713.2",
+      "resolved": "https://registry.npmjs.org/@dashevo/wasm-dpp/-/wasm-dpp-1.1.0-pr.1713.2.tgz",
+      "integrity": "sha512-9ia0ftS/vywwi/ts1YVHo6c10GjvRXocyi8VD1+Teu53YSTwmWESxiW95S7E1r7xXgFcjhtqpAIXDn7rRo3BvA==",
       "dependencies": {
         "@dashevo/bls": "~1.2.9",
         "bs58": "^4.0.1",
@@ -330,9 +330,9 @@
       }
     },
     "node_modules/@dashevo/withdrawals-contract": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@dashevo/withdrawals-contract/-/withdrawals-contract-1.0.0-beta.4.tgz",
-      "integrity": "sha512-LUFtCTJCYM8/U8fDdhyBzaOXQXaTJn8anlb5v9lLL8SwpFC/JYTRTrCBRMRWCEQZgYQMt+z1+MsUda5UmS+rBg=="
+      "version": "1.1.0-pr.1713.2",
+      "resolved": "https://registry.npmjs.org/@dashevo/withdrawals-contract/-/withdrawals-contract-1.1.0-pr.1713.2.tgz",
+      "integrity": "sha512-S8jxXUN4pVPj6NYcDYJpa81HAaIVALi6akZMr6n3p6KWIoLBqKj3TDjovvGOAAmPbXO4PgXHJDIuB5sp4Wks4A=="
     },
     "node_modules/@dashevo/x11-hash-js": {
       "version": "1.0.2",
@@ -747,9 +747,9 @@
       "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw=="
     },
     "node_modules/@yarnpkg/core": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@yarnpkg/core/-/core-4.1.1.tgz",
-      "integrity": "sha512-Py26fODbsgcFdoq/iYEbqZPkIrjWcICMf/BuI7EDR6YjHmD+FQ4HyqfeanhvePsORCHNAwfqsnr1OqrfKZFrEA==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/core/-/core-4.1.2.tgz",
+      "integrity": "sha512-2jcHRIJwjOOdl7mFysdz5FLxl4JWWJJEwesaKMRYmVwcqXolItX/gXdL3AjTD0umlBySccK9TulRD2/YL2Y0YQ==",
       "dependencies": {
         "@arcanis/slice-ansi": "^1.1.1",
         "@types/semver": "^7.1.0",
@@ -760,7 +760,7 @@
         "@yarnpkg/shell": "^4.0.2",
         "camelcase": "^5.3.1",
         "chalk": "^3.0.0",
-        "ci-info": "^3.2.0",
+        "ci-info": "^4.0.0",
         "clipanion": "^4.0.0-rc.2",
         "cross-spawn": "7.0.3",
         "diff": "^5.1.0",
@@ -873,19 +873,19 @@
       }
     },
     "node_modules/@yarnpkg/pnp/node_modules/@types/node": {
-      "version": "18.19.41",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.41.tgz",
-      "integrity": "sha512-LX84pRJ+evD2e2nrgYCHObGWkiQJ1mL+meAgbvnwk/US6vmMY7S2ygBTGV2Jw91s9vUsLSXeDEkUHZIJGLrhsg==",
+      "version": "18.19.44",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.44.tgz",
+      "integrity": "sha512-ZsbGerYg72WMXUIE9fYxtvfzLEuq6q8mKERdWFnqTmOvudMxnz+CBNRoOwJ2kNpFOncrKjT1hZwxjlFgQ9qvQA==",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
     },
     "node_modules/@yarnpkg/pnpify": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@yarnpkg/pnpify/-/pnpify-4.1.0.tgz",
-      "integrity": "sha512-N5u4kowx3q0dwc+JFl5WAO91h8YxqmFYEHL5Z2Iy7T9EMhWw6q7/NevjwstTu1/EMRQBbnvLgAmG6mmgu7Khzg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/pnpify/-/pnpify-4.1.1.tgz",
+      "integrity": "sha512-uAiWNMczY8ZykWWKRypThZerZIDC44I25duFaB0dgDeW/zXg/nkYToo3STRff9eJiyVrnAnUtlA06W9hbcXRIQ==",
       "dependencies": {
-        "@yarnpkg/core": "^4.0.5",
+        "@yarnpkg/core": "^4.1.2",
         "@yarnpkg/fslib": "^3.1.0",
         "@yarnpkg/nm": "^4.0.2",
         "clipanion": "^4.0.0-rc.2",
@@ -1259,9 +1259,9 @@
       }
     },
     "node_modules/ci-info": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.0.0.tgz",
+      "integrity": "sha512-TdHqgGf9odd8SXNuxtUBVx8Nv+qZOejE6qyqiy5NtbYYQOeFa6zmHkxlPzmaLxWWHsU6nJmB7AETdVPi+2NBUg==",
       "funding": [
         {
           "type": "github",
@@ -1422,21 +1422,21 @@
       "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
     },
     "node_modules/dash": {
-      "version": "4.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/dash/-/dash-4.0.0-beta.4.tgz",
-      "integrity": "sha512-CrV2fHJucQDs/ZQ9+r28Z2v72TJdXu1fgrBK9bra8slG6WawnUFPKf34GFVmBAEybYomr3Vou5kiIQOLHvy65w==",
+      "version": "4.1.0-pr.1713.2",
+      "resolved": "https://registry.npmjs.org/dash/-/dash-4.1.0-pr.1713.2.tgz",
+      "integrity": "sha512-mv6kXwddZwvRtejjx4U9VLHKDtYlzxUDulVfPXAaVn/lVqNZhovHGMt0DaSDxNIbKUgSFE90AiLNmIe2QTYFuA==",
       "dependencies": {
         "@dashevo/bls": "~1.2.9",
-        "@dashevo/dapi-client": "1.0.0-beta.4",
-        "@dashevo/dapi-grpc": "1.0.0-beta.4",
+        "@dashevo/dapi-client": "1.1.0-pr.1713.2",
+        "@dashevo/dapi-grpc": "1.1.0-pr.1713.2",
         "@dashevo/dashcore-lib": "~0.21.3",
-        "@dashevo/dashpay-contract": "1.0.0-beta.4",
-        "@dashevo/dpns-contract": "1.0.0-beta.4",
-        "@dashevo/grpc-common": "1.0.0-beta.4",
-        "@dashevo/masternode-reward-shares-contract": "1.0.0-beta.4",
-        "@dashevo/wallet-lib": "8.0.0-beta.4",
-        "@dashevo/wasm-dpp": "1.0.0-beta.4",
-        "@dashevo/withdrawals-contract": "1.0.0-beta.4",
+        "@dashevo/dashpay-contract": "1.1.0-pr.1713.2",
+        "@dashevo/dpns-contract": "1.1.0-pr.1713.2",
+        "@dashevo/grpc-common": "1.1.0-pr.1713.2",
+        "@dashevo/masternode-reward-shares-contract": "1.1.0-pr.1713.2",
+        "@dashevo/wallet-lib": "8.1.0-pr.1713.2",
+        "@dashevo/wasm-dpp": "1.1.0-pr.1713.2",
+        "@dashevo/withdrawals-contract": "1.1.0-pr.1713.2",
         "bs58": "^4.0.1",
         "node-inspect-extracted": "^1.0.8",
         "winston": "^3.2.1"
@@ -1597,9 +1597,9 @@
       }
     },
     "node_modules/elliptic": {
-      "version": "6.5.6",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.6.tgz",
-      "integrity": "sha512-mpzdtpeCLuS3BmE3pO3Cpp5bbjlOPY2Q0PgoF+Od1XZrHLYI28Xe3ossCmYCQt11FQKEYd9+PF8jymTvtWJSHQ==",
+      "version": "6.5.7",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.7.tgz",
+      "integrity": "sha512-ESVCtTwiA+XhY3wyh24QqRGBoP3rEdDUl3EDUUo9tft074fi19IrdpH7hLCMMP3CIj7jb3W96rn8lt/BqIlt5Q==",
       "dependencies": {
         "bn.js": "^4.11.9",
         "brorand": "^1.1.0",
@@ -3223,17 +3223,22 @@
       }
     },
     "node_modules/protobufjs/node_modules/@types/node": {
-      "version": "20.14.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.11.tgz",
-      "integrity": "sha512-kprQpL8MMeszbz6ojB5/tU8PLN4kesnN8Gjzw349rDlNgsSzg90lAVj3llK99Dh7JON+t9AuscPPFW6mPbTnSA==",
+      "version": "22.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.3.0.tgz",
+      "integrity": "sha512-nrWpWVaDZuaVc5X84xJ0vNrLvomM205oQyLsRt7OHNZbSHslcWsvgFR7O7hire2ZonjLrWBbedmotmIlJDVd6g==",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.18.2"
       }
     },
     "node_modules/protobufjs/node_modules/long": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
       "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+    },
+    "node_modules/protobufjs/node_modules/undici-types": {
+      "version": "6.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.18.2.tgz",
+      "integrity": "sha512-5ruQbENj95yDYJNS3TvcaxPMshV7aizdv/hWYjGIKoANWKjhWNBsr2YEuYZKodQulB1b8l7ILOuDQep3afowQQ=="
     },
     "node_modules/prr": {
       "version": "1.0.1",
@@ -3982,9 +3987,9 @@
       }
     },
     "node_modules/winston": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-3.13.1.tgz",
-      "integrity": "sha512-SvZit7VFNvXRzbqGHsv5KSmgbEYR5EiQfDAL9gxYkRqa934Hnk++zze0wANKtMHcy/gI4W/3xmSDwlhf865WGw==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.14.2.tgz",
+      "integrity": "sha512-CO8cdpBB2yqzEf8v895L+GNKYJiEq8eKlHU38af3snQBQ+sdAIUepjMSguOIJC7ICbzm0ZI+Af2If4vIJrtmOg==",
       "dependencies": {
         "@colors/colors": "^1.6.0",
         "@dabh/diagnostics": "^2.0.2",
@@ -4210,15 +4215,15 @@
       }
     },
     "@dashevo/dapi-client": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@dashevo/dapi-client/-/dapi-client-1.0.0-beta.4.tgz",
-      "integrity": "sha512-wUAlXGdFxUG9ZY1UmTTwwN5JVcf0c0oCCODUJzOlz/M+9HjAXz01OAFhaT/mWggHRtVpvY4shSh4/WS03Qge1w==",
+      "version": "1.1.0-pr.1713.2",
+      "resolved": "https://registry.npmjs.org/@dashevo/dapi-client/-/dapi-client-1.1.0-pr.1713.2.tgz",
+      "integrity": "sha512-2Y/E3DZKfCNGaFgH8eonT2ih2JlgszRga9fRqthL9+Soukor31SM9mCYFiIkfES9e44DtO0YyaCSXDiFjyYU0g==",
       "requires": {
-        "@dashevo/dapi-grpc": "1.0.0-beta.4",
-        "@dashevo/dash-spv": "1.0.0-beta.4",
+        "@dashevo/dapi-grpc": "1.1.0-pr.1713.2",
+        "@dashevo/dash-spv": "2.1.0-pr.1713.2",
         "@dashevo/dashcore-lib": "~0.21.3",
-        "@dashevo/grpc-common": "1.0.0-beta.4",
-        "@dashevo/wasm-dpp": "1.0.0-beta.4",
+        "@dashevo/grpc-common": "1.1.0-pr.1713.2",
+        "@dashevo/wasm-dpp": "1.1.0-pr.1713.2",
         "bs58": "^4.0.1",
         "cbor": "^8.0.0",
         "google-protobuf": "^3.12.2",
@@ -4230,11 +4235,11 @@
       }
     },
     "@dashevo/dapi-grpc": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@dashevo/dapi-grpc/-/dapi-grpc-1.0.0-beta.4.tgz",
-      "integrity": "sha512-THmMUJ8enBgE6FyGP+lpSgx0Ii6JCx4d1CSlLyu2eryFMAfxIcScfF3DEvRR4QbvzgRRC+J9wYZZIAYo7hWbrg==",
+      "version": "1.1.0-pr.1713.2",
+      "resolved": "https://registry.npmjs.org/@dashevo/dapi-grpc/-/dapi-grpc-1.1.0-pr.1713.2.tgz",
+      "integrity": "sha512-bpxyOZ7tXXWFzYHQ5jjJBlt4VHsbhIyiDHEqBk4mBrHtkELfS2KmEYvfwn2dFUc9B1ryQUxmZewtgOaEOy3Nmw==",
       "requires": {
-        "@dashevo/grpc-common": "1.0.0-beta.4",
+        "@dashevo/grpc-common": "1.1.0-pr.1713.2",
         "@dashevo/protobufjs": "6.10.5",
         "@grpc/grpc-js": "1.4.4",
         "@improbable-eng/grpc-web": "^0.15.0",
@@ -4248,9 +4253,9 @@
       "integrity": "sha512-rt0PzGzqplqERWVIMLlBxm4mJqjFTYNUFRhIccbfaF/MDyd0/585krGOWIhe0Sis9XQNA/FJlxxRjtPXIcyyCg=="
     },
     "@dashevo/dash-spv": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@dashevo/dash-spv/-/dash-spv-1.0.0-beta.4.tgz",
-      "integrity": "sha512-cdnrMom24/68ihMljEKalYv5gmcNCmZAmMC3fHEpClQc75CJdQm2sRkRPBfZxlxMFD8eaiUyXIUUE3cdqGN1ig==",
+      "version": "2.1.0-pr.1713.2",
+      "resolved": "https://registry.npmjs.org/@dashevo/dash-spv/-/dash-spv-2.1.0-pr.1713.2.tgz",
+      "integrity": "sha512-vXT9nAJG2l6W1E16RtCMRNJ9RUl/dXUQA/TdYxyAwBDgLyO+MB4yLXcgV8jRC1WFtuVL5i0QcmurOETGamXbPQ==",
       "requires": {
         "@dashevo/dark-gravity-wave": "^1.1.1",
         "@dashevo/dash-util": "^2.0.3",
@@ -4289,19 +4294,19 @@
       }
     },
     "@dashevo/dashpay-contract": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@dashevo/dashpay-contract/-/dashpay-contract-1.0.0-beta.4.tgz",
-      "integrity": "sha512-77CsG8MvCMAHU+ee8DABzzyvwA9ZBeB1wFwnaTOvQdg8vzs4p1q8Ni7b7oCCOl+ZHtWDckoDxFQrWBV10TzxCQ=="
+      "version": "1.1.0-pr.1713.2",
+      "resolved": "https://registry.npmjs.org/@dashevo/dashpay-contract/-/dashpay-contract-1.1.0-pr.1713.2.tgz",
+      "integrity": "sha512-9RAbTM/88QWZJbCUXqSthnFIZlfM4r93iZmLDWnVq+z+yCgxTe7TYBeq/IbgoAwRmsEh1TlGJUFxYFg/LY3J4w=="
     },
     "@dashevo/dpns-contract": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@dashevo/dpns-contract/-/dpns-contract-1.0.0-beta.4.tgz",
-      "integrity": "sha512-epyIlAR2DqoBY0xxlNv3HfpkZkFS2tAQDW4S/MfNNpDM1CGgqyVDIJj1jGbOPybWA+BPrsTtyLJolVtBYO50MQ=="
+      "version": "1.1.0-pr.1713.2",
+      "resolved": "https://registry.npmjs.org/@dashevo/dpns-contract/-/dpns-contract-1.1.0-pr.1713.2.tgz",
+      "integrity": "sha512-gBAUqUq7a/P0CNWNOsk71IdWCmZUnPQcxv/WrnS4t+FVXTDnE3RSbTPS6sEabIIF1dw/PtAGMKGDFmnBpQ2IUA=="
     },
     "@dashevo/grpc-common": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@dashevo/grpc-common/-/grpc-common-1.0.0-beta.4.tgz",
-      "integrity": "sha512-mbJDNSqQsOhcTr6xfur8ehldY8BVdVdP1cp83srA7d6cPcnUBKvAPeZM4LpFzQ8npQS3i2xvNFL2vqv4Y09cUg==",
+      "version": "1.1.0-pr.1713.2",
+      "resolved": "https://registry.npmjs.org/@dashevo/grpc-common/-/grpc-common-1.1.0-pr.1713.2.tgz",
+      "integrity": "sha512-mfOP4OXKxSWoKDgKxShP1PAlCzXPh7GPCjVGw1zPpvxBe2G/CBqPN01MjHe6uxbJzYRgKcxVez/Ov5+7g9GVLA==",
       "requires": {
         "@dashevo/protobufjs": "6.10.5",
         "@grpc/grpc-js": "1.4.4",
@@ -4313,9 +4318,9 @@
       }
     },
     "@dashevo/masternode-reward-shares-contract": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@dashevo/masternode-reward-shares-contract/-/masternode-reward-shares-contract-1.0.0-beta.4.tgz",
-      "integrity": "sha512-i4QEmyamBCl7ZfD0T7LhnNskgARNPMnJw5buGLJ0waj8tzhzT7nMMzASBRrlOaK2xy15Y3JUtjh8ma2/fT8Yuw=="
+      "version": "1.1.0-pr.1713.2",
+      "resolved": "https://registry.npmjs.org/@dashevo/masternode-reward-shares-contract/-/masternode-reward-shares-contract-1.1.0-pr.1713.2.tgz",
+      "integrity": "sha512-MduiOsZOb9BuHhTy+zhgkGxU8nGbb5TJHDKXu+aphos3puV0nyFE/0M2AAXazyeCqCzdzBhfbzdi9Ur6R9Yjbg=="
     },
     "@dashevo/protobufjs": {
       "version": "6.10.5",
@@ -4350,14 +4355,14 @@
       }
     },
     "@dashevo/wallet-lib": {
-      "version": "8.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@dashevo/wallet-lib/-/wallet-lib-8.0.0-beta.4.tgz",
-      "integrity": "sha512-0E5i8KVB61+HKJ2VXRVZUcRxPs+vERRTcCTEtofQgOg/RUaAmLT9U66xNJ729BM5elX/aShy0MWTPqm8sAZRHw==",
+      "version": "8.1.0-pr.1713.2",
+      "resolved": "https://registry.npmjs.org/@dashevo/wallet-lib/-/wallet-lib-8.1.0-pr.1713.2.tgz",
+      "integrity": "sha512-xi1+4sk0eUpW0y1/+nAkwP3BjHLT+SpiSmqkV5DCdarYVsbLElYkGStxhHpGt4pqP1zEkTL8Ru9dhBXgNkdIPQ==",
       "requires": {
-        "@dashevo/dapi-client": "1.0.0-beta.4",
+        "@dashevo/dapi-client": "1.1.0-pr.1713.2",
         "@dashevo/dashcore-lib": "~0.21.3",
-        "@dashevo/grpc-common": "1.0.0-beta.4",
-        "@dashevo/wasm-dpp": "1.0.0-beta.4",
+        "@dashevo/grpc-common": "1.1.0-pr.1713.2",
+        "@dashevo/wasm-dpp": "1.1.0-pr.1713.2",
         "@yarnpkg/pnpify": "^4.0.0-rc.42",
         "cbor": "^8.0.0",
         "crypto-js": "^4.2.0",
@@ -4368,9 +4373,9 @@
       }
     },
     "@dashevo/wasm-dpp": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@dashevo/wasm-dpp/-/wasm-dpp-1.0.0-beta.4.tgz",
-      "integrity": "sha512-WyctJC6JTO4HM+9bCss97MEBtckawB9QWOVvErSY7Oqu2J/oRcc1LVYBtT8rMnANw+IC4mHqAMaQVOkgz9y2fw==",
+      "version": "1.1.0-pr.1713.2",
+      "resolved": "https://registry.npmjs.org/@dashevo/wasm-dpp/-/wasm-dpp-1.1.0-pr.1713.2.tgz",
+      "integrity": "sha512-9ia0ftS/vywwi/ts1YVHo6c10GjvRXocyi8VD1+Teu53YSTwmWESxiW95S7E1r7xXgFcjhtqpAIXDn7rRo3BvA==",
       "requires": {
         "@dashevo/bls": "~1.2.9",
         "bs58": "^4.0.1",
@@ -4379,9 +4384,9 @@
       }
     },
     "@dashevo/withdrawals-contract": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@dashevo/withdrawals-contract/-/withdrawals-contract-1.0.0-beta.4.tgz",
-      "integrity": "sha512-LUFtCTJCYM8/U8fDdhyBzaOXQXaTJn8anlb5v9lLL8SwpFC/JYTRTrCBRMRWCEQZgYQMt+z1+MsUda5UmS+rBg=="
+      "version": "1.1.0-pr.1713.2",
+      "resolved": "https://registry.npmjs.org/@dashevo/withdrawals-contract/-/withdrawals-contract-1.1.0-pr.1713.2.tgz",
+      "integrity": "sha512-S8jxXUN4pVPj6NYcDYJpa81HAaIVALi6akZMr6n3p6KWIoLBqKj3TDjovvGOAAmPbXO4PgXHJDIuB5sp4Wks4A=="
     },
     "@dashevo/x11-hash-js": {
       "version": "1.0.2",
@@ -4729,9 +4734,9 @@
       "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw=="
     },
     "@yarnpkg/core": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@yarnpkg/core/-/core-4.1.1.tgz",
-      "integrity": "sha512-Py26fODbsgcFdoq/iYEbqZPkIrjWcICMf/BuI7EDR6YjHmD+FQ4HyqfeanhvePsORCHNAwfqsnr1OqrfKZFrEA==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/core/-/core-4.1.2.tgz",
+      "integrity": "sha512-2jcHRIJwjOOdl7mFysdz5FLxl4JWWJJEwesaKMRYmVwcqXolItX/gXdL3AjTD0umlBySccK9TulRD2/YL2Y0YQ==",
       "requires": {
         "@arcanis/slice-ansi": "^1.1.1",
         "@types/semver": "^7.1.0",
@@ -4742,7 +4747,7 @@
         "@yarnpkg/shell": "^4.0.2",
         "camelcase": "^5.3.1",
         "chalk": "^3.0.0",
-        "ci-info": "^3.2.0",
+        "ci-info": "^4.0.0",
         "clipanion": "^4.0.0-rc.2",
         "cross-spawn": "7.0.3",
         "diff": "^5.1.0",
@@ -4827,9 +4832,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "18.19.41",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.41.tgz",
-          "integrity": "sha512-LX84pRJ+evD2e2nrgYCHObGWkiQJ1mL+meAgbvnwk/US6vmMY7S2ygBTGV2Jw91s9vUsLSXeDEkUHZIJGLrhsg==",
+          "version": "18.19.44",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.44.tgz",
+          "integrity": "sha512-ZsbGerYg72WMXUIE9fYxtvfzLEuq6q8mKERdWFnqTmOvudMxnz+CBNRoOwJ2kNpFOncrKjT1hZwxjlFgQ9qvQA==",
           "requires": {
             "undici-types": "~5.26.4"
           }
@@ -4837,11 +4842,11 @@
       }
     },
     "@yarnpkg/pnpify": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@yarnpkg/pnpify/-/pnpify-4.1.0.tgz",
-      "integrity": "sha512-N5u4kowx3q0dwc+JFl5WAO91h8YxqmFYEHL5Z2Iy7T9EMhWw6q7/NevjwstTu1/EMRQBbnvLgAmG6mmgu7Khzg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/pnpify/-/pnpify-4.1.1.tgz",
+      "integrity": "sha512-uAiWNMczY8ZykWWKRypThZerZIDC44I25duFaB0dgDeW/zXg/nkYToo3STRff9eJiyVrnAnUtlA06W9hbcXRIQ==",
       "requires": {
-        "@yarnpkg/core": "^4.0.5",
+        "@yarnpkg/core": "^4.1.2",
         "@yarnpkg/fslib": "^3.1.0",
         "@yarnpkg/nm": "^4.0.2",
         "clipanion": "^4.0.0-rc.2",
@@ -5104,9 +5109,9 @@
       "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="
     },
     "ci-info": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.0.0.tgz",
+      "integrity": "sha512-TdHqgGf9odd8SXNuxtUBVx8Nv+qZOejE6qyqiy5NtbYYQOeFa6zmHkxlPzmaLxWWHsU6nJmB7AETdVPi+2NBUg=="
     },
     "cipher-base": {
       "version": "1.0.4",
@@ -5245,21 +5250,21 @@
       "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
     },
     "dash": {
-      "version": "4.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/dash/-/dash-4.0.0-beta.4.tgz",
-      "integrity": "sha512-CrV2fHJucQDs/ZQ9+r28Z2v72TJdXu1fgrBK9bra8slG6WawnUFPKf34GFVmBAEybYomr3Vou5kiIQOLHvy65w==",
+      "version": "4.1.0-pr.1713.2",
+      "resolved": "https://registry.npmjs.org/dash/-/dash-4.1.0-pr.1713.2.tgz",
+      "integrity": "sha512-mv6kXwddZwvRtejjx4U9VLHKDtYlzxUDulVfPXAaVn/lVqNZhovHGMt0DaSDxNIbKUgSFE90AiLNmIe2QTYFuA==",
       "requires": {
         "@dashevo/bls": "~1.2.9",
-        "@dashevo/dapi-client": "1.0.0-beta.4",
-        "@dashevo/dapi-grpc": "1.0.0-beta.4",
+        "@dashevo/dapi-client": "1.1.0-pr.1713.2",
+        "@dashevo/dapi-grpc": "1.1.0-pr.1713.2",
         "@dashevo/dashcore-lib": "~0.21.3",
-        "@dashevo/dashpay-contract": "1.0.0-beta.4",
-        "@dashevo/dpns-contract": "1.0.0-beta.4",
-        "@dashevo/grpc-common": "1.0.0-beta.4",
-        "@dashevo/masternode-reward-shares-contract": "1.0.0-beta.4",
-        "@dashevo/wallet-lib": "8.0.0-beta.4",
-        "@dashevo/wasm-dpp": "1.0.0-beta.4",
-        "@dashevo/withdrawals-contract": "1.0.0-beta.4",
+        "@dashevo/dashpay-contract": "1.1.0-pr.1713.2",
+        "@dashevo/dpns-contract": "1.1.0-pr.1713.2",
+        "@dashevo/grpc-common": "1.1.0-pr.1713.2",
+        "@dashevo/masternode-reward-shares-contract": "1.1.0-pr.1713.2",
+        "@dashevo/wallet-lib": "8.1.0-pr.1713.2",
+        "@dashevo/wasm-dpp": "1.1.0-pr.1713.2",
+        "@dashevo/withdrawals-contract": "1.1.0-pr.1713.2",
         "bs58": "^4.0.1",
         "node-inspect-extracted": "^1.0.8",
         "winston": "^3.2.1"
@@ -5370,9 +5375,9 @@
       "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ=="
     },
     "elliptic": {
-      "version": "6.5.6",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.6.tgz",
-      "integrity": "sha512-mpzdtpeCLuS3BmE3pO3Cpp5bbjlOPY2Q0PgoF+Od1XZrHLYI28Xe3ossCmYCQt11FQKEYd9+PF8jymTvtWJSHQ==",
+      "version": "6.5.7",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.7.tgz",
+      "integrity": "sha512-ESVCtTwiA+XhY3wyh24QqRGBoP3rEdDUl3EDUUo9tft074fi19IrdpH7hLCMMP3CIj7jb3W96rn8lt/BqIlt5Q==",
       "requires": {
         "bn.js": "^4.11.9",
         "brorand": "^1.1.0",
@@ -6590,17 +6595,22 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "20.14.11",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.11.tgz",
-          "integrity": "sha512-kprQpL8MMeszbz6ojB5/tU8PLN4kesnN8Gjzw349rDlNgsSzg90lAVj3llK99Dh7JON+t9AuscPPFW6mPbTnSA==",
+          "version": "22.3.0",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-22.3.0.tgz",
+          "integrity": "sha512-nrWpWVaDZuaVc5X84xJ0vNrLvomM205oQyLsRt7OHNZbSHslcWsvgFR7O7hire2ZonjLrWBbedmotmIlJDVd6g==",
           "requires": {
-            "undici-types": "~5.26.4"
+            "undici-types": "~6.18.2"
           }
         },
         "long": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
           "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+        },
+        "undici-types": {
+          "version": "6.18.2",
+          "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.18.2.tgz",
+          "integrity": "sha512-5ruQbENj95yDYJNS3TvcaxPMshV7aizdv/hWYjGIKoANWKjhWNBsr2YEuYZKodQulB1b8l7ILOuDQep3afowQQ=="
         }
       }
     },
@@ -7148,9 +7158,9 @@
       }
     },
     "winston": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-3.13.1.tgz",
-      "integrity": "sha512-SvZit7VFNvXRzbqGHsv5KSmgbEYR5EiQfDAL9gxYkRqa934Hnk++zze0wANKtMHcy/gI4W/3xmSDwlhf865WGw==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.14.2.tgz",
+      "integrity": "sha512-CO8cdpBB2yqzEf8v895L+GNKYJiEq8eKlHU38af3snQBQ+sdAIUepjMSguOIJC7ICbzm0ZI+Af2If4vIJrtmOg==",
       "requires": {
         "@colors/colors": "^1.6.0",
         "@dabh/diagnostics": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "platform-readme-tutorials",
-  "version": "1.0.0-beta",
+  "version": "1.1-dev",
   "description": "Tutorial code for https://docs.dash.org/platform",
   "main": "connect.js",
   "scripts": {
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/dashpay/platform-tutorials#readme",
   "dependencies": {
-    "dash": "^4.0.0-beta.4"
+    "dash": "~4.1.0-dev"
   },
   "devDependencies": {
     "dotenv": "^16.0.0",


### PR DESCRIPTION
Update to v1.1.0-dev.1 (current testnet release), update dpns logic to use records.identity field, cleanup misc stuff.